### PR TITLE
Fix meta() BQL function when used in the FROM clause

### DIFF
--- a/beanquery/query_env.py
+++ b/beanquery/query_env.py
@@ -379,7 +379,7 @@ class Meta(query_compile.EvalFunction):
 
     def __call__(self, context):
         args = self.eval_args(context)
-        meta = context.posting.meta
+        meta = context.posting.meta if context.posting else None
         if meta is None:
             return None
         return meta.get(args[0], None)


### PR DESCRIPTION
Using the BQL meta() function is the query FROM clause does not make
much sense as there are no posting to operate on in this context, only
entries, but raising an exception does not seem useful. Make meta()
simply return None in this context.