### PR TITLE
Fix pylint violations in query_env.py.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -42,3 +42,6 @@ disable=
   unused-variable,
   unused-wildcard-import,
   wildcard-import,
+  # existing violations, revist them
+  too-many-lines,
+  attribute-defined-outside-init,

--- a/beanquery/query_env.py
+++ b/beanquery/query_env.py
@@ -26,8 +26,8 @@ from beancount.core import data
 from beancount.core import getters
 from beancount.core import convert
 from beancount.core import prices
-from beanquery import query_compile
 from beancount.utils.date_utils import parse_date_liberally
+from beanquery import query_compile
 
 
 # Non-aggregating functions. These functionals maintain no state.
@@ -1443,8 +1443,7 @@ class FileLocationColumn(query_compile.EvalColumn):
         if context.posting.meta is not None:
             return '{}:{:d}:'.format(context.posting.meta.get("filename", "N/A"),
                                      context.posting.meta.get("lineno", 0))
-        else:
-            return '' # Unknown.
+        return '' # Unknown.
 
 class DateColumn(query_compile.EvalColumn):
     "The date of the parent transaction for this posting."


### PR DESCRIPTION
Refs #8. I am adding more complicated violations to `.pylintrc` and will go over them once I fully enable pylint on all files.