### PR TITLE
Remove bin/bean-query from the repository

### DIFF
--- a/beanquery/shell.py
+++ b/beanquery/shell.py
@@ -738,7 +738,7 @@ _SUPPORTED_FORMATS = ('text', 'csv')
               help="Output filename.")
 @click.option('--no-errors', '-q', is_flag=True,
               help="Do not report errors.")
-@click.version_option()
+@click.version_option(prog_name='bean-query', message='%(prog)s %(version)s')
 def main(filename, query, numberify, output_format, output, no_errors):
     """An interactive interpreter for the Beancount Query Language.
 

--- a/bin/bean-query
+++ b/bin/bean-query
@@ -1,4 +1,0 @@
-#!/usr/bin/env python3
-__copyright__ = "Copyright (C) 2013-2017  Martin Blais"
-__license__ = "GNU GPLv2"
-from beanquery.shell import main; main()

--- a/etc/env
+++ b/etc/env
@@ -1,3 +1,3 @@
 #!/bin/sh
-USERPATH=$USERPATH:$PROJDIR/bin
 PYTHONPATH=$PYTHONPATH:$PROJDIR
+alias bean-query='python -m beanquey'


### PR DESCRIPTION
The executable is created by setuptools on install and alternatively
the tool can be run from the source directory with 'python -m beanquery'.