### PR TITLE
BQL functions decimal(str, [int]), round(decimal, int)

### DIFF
--- a/beanquery/query_env.py
+++ b/beanquery/query_env.py
@@ -14,7 +14,7 @@ import re
 import textwrap
 from decimal import Decimal
 
-from beancount.core.number import ZERO
+from beancount.core.number import ZERO, D
 from beancount.core.data import Transaction
 from beancount.core.compare import hash_entry
 from beancount.core import amount
@@ -55,6 +55,31 @@ class NegPosition(_Neg):
 class NegInventory(_Neg):
     __intypes__ = [inventory.Inventory]
 
+class ToDecimal(query_compile.EvalFunction):
+    """Converts a string into a Decimal type.
+    Defaults to no value for non-decimal values."""
+    __intypes__ = [str]
+
+    def __init__(self, operands):
+        super().__init__(operands, Decimal)
+
+    def __call__(self, context):
+        args = self.eval_args(context)
+
+        # ToDecimal has no default value
+        # ToDecimalDefault will pass a default value as the second arg
+        value = args[1] if len(args) > 1 else None
+        try:
+            if args[0] != '': # '' parses to D('0')
+                value = D(args[0])
+        except ValueError as ex:
+            pass # default is used instead
+        return value
+
+class ToDecimalDefault(ToDecimal):
+    """Converts a string into a Decimal type.
+    Defaults to second argument for non-decimal values."""
+    __intypes__ = [str, Decimal]
 
 class AbsDecimal(query_compile.EvalFunction):
     "Absolute value."
@@ -911,6 +936,8 @@ SIMPLE_FUNCTIONS = {
     ('safediv', Decimal, Decimal)                        : SafeDiv,
     ('safediv', Decimal, int)                            : SafeDivInt,
     'length'                                             : Length,
+    ('decimal', str)                                     : ToDecimal,
+    ('decimal', str, Decimal)                            : ToDecimalDefault,
     'str'                                                : Str,
     'maxwidth'                                           : MaxWidth,
     'substr'                                             : SubStr,

--- a/beanquery/query_env.py
+++ b/beanquery/query_env.py
@@ -92,6 +92,17 @@ class AbsDecimal(query_compile.EvalFunction):
         args = self.eval_args(context)
         return abs(args[0])
 
+class RoundDecimal(query_compile.EvalFunction):
+    "Rounds a decimal to the specified number of decimal digits"
+    __intypes__ = [Decimal, int]
+
+    def __init__(self, operands):
+        super().__init__(operands, Decimal)
+
+    def __call__(self, context):
+        args = self.eval_args(context)
+        return round(args[0], args[1])
+
 class AbsPosition(query_compile.EvalFunction):
     "Absolute value."
     __intypes__ = [position.Position]
@@ -938,6 +949,7 @@ SIMPLE_FUNCTIONS = {
     'length'                                             : Length,
     ('decimal', str)                                     : ToDecimal,
     ('decimal', str, Decimal)                            : ToDecimalDefault,
+    ('round', Decimal, int)                              : RoundDecimal,
     'str'                                                : Str,
     'maxwidth'                                           : MaxWidth,
     'substr'                                             : SubStr,

--- a/beanquery/query_env_test.py
+++ b/beanquery/query_env_test.py
@@ -357,5 +357,31 @@ class TestEnv(unittest.TestCase):
                                         + '* number(convert(units(position), "USD"))')
         self.assertEqual([(D('0.00'),)], rrows)
 
+    @parser.parse_doc()
+    def test_Round(self, entries, _, options_map):
+        """
+        2016-11-20 * "ok"
+          Assets:Banking          0.9561234567 INDX { 5 USD, 2016-10-30 }
+        """
+        rtypes, rrows = query.run_query(entries, options_map,
+                                        'SELECT round(number(units(position)), 0)')
+        self.assertEqual([(D('1'),)], rrows)
+
+        rtypes, rrows = query.run_query(entries, options_map,
+                                        'SELECT round(number(units(position)), 1)')
+        self.assertEqual([(D('1'),)], rrows)
+
+        rtypes, rrows = query.run_query(entries, options_map,
+                                        'SELECT round(number(units(position)), 2)')
+        self.assertEqual([(D('0.96'),)], rrows)
+
+        rtypes, rrows = query.run_query(entries, options_map,
+                                        'SELECT round(number(units(position)), 3)')
+        self.assertEqual([(D('0.956'),)], rrows)
+
+        rtypes, rrows = query.run_query(entries, options_map,
+                                        'SELECT round(number(units(position)), 4)')
+        self.assertEqual([(D('0.9561'),)], rrows)
+
 if __name__ == '__main__':
     unittest.main()

--- a/beanquery/query_env_test.py
+++ b/beanquery/query_env_test.py
@@ -295,6 +295,67 @@ class TestEnv(unittest.TestCase):
                                         'SELECT date_add(date, -1) as m')
         self.assertEqual([(datetime.date(2016, 11, 19),)], rrows)
 
+    @parser.parse_doc()
+    def test_ToDecimal(self, entries, _, options_map):
+        """
+        2016-11-19 commodity INDX
+          pcnt_stocks_us: 0.60
+          pcnt_stocks_int: 0.40
+
+        2016-11-20 * "ok"
+          Assets:Banking          -1 INDX { 5 USD, 2016-10-30 }
+
+        2016-11-21 price INDX 20 USD
+        """
+        rtypes, rrows = query.run_query(entries, options_map,
+                                        'SELECT decimal("foo") as m')
+        self.assertEqual([(None,)], rrows)
+
+        rtypes, rrows = query.run_query(entries, options_map,
+                                        'SELECT decimal("foo", 1.0) as m')
+        self.assertEqual([(D('1.0'),)], rrows)
+
+        rtypes, rrows = query.run_query(entries, options_map,
+                                        'SELECT decimal("2.0") as m')
+        self.assertEqual([(D('2.0'),)], rrows)
+
+        rtypes, rrows = query.run_query(entries, options_map,
+                                        'SELECT decimal("2.0", 1.0) as m')
+        self.assertEqual([(D('2.0'),)], rrows)
+
+        rtypes, rrows = query.run_query(entries, options_map,
+                                        'SELECT decimal(getitem(commodity_meta(commodity('
+                                        + 'units(position))), "pcnt_stocks_us")) as m')
+        self.assertEqual([(D('0.6'),)], rrows)
+
+        rtypes, rrows = query.run_query(entries, options_map,
+                                        'SELECT decimal(getitem(commodity_meta(commodity('
+                                        + 'units(position))), "pcnt_bonds_us")) as m')
+        self.assertEqual([(None,)], rrows)
+
+        rtypes, rrows = query.run_query(entries, options_map,
+                                        'SELECT decimal(getitem(commodity_meta(commodity('
+                                        + 'units(position))), "pcnt_bonds_us"), 0.0) as m')
+        self.assertEqual([(D('0.0'),)], rrows)
+
+        rtypes, rrows = query.run_query(entries, options_map,
+                                        'SELECT decimal(getitem(commodity_meta('
+                                        + 'commodity(units(position))), "pcnt_stocks_us"))'
+                                        + '* number(convert(units(position), "USD")) as m')
+        self.assertEqual([(D('-12.00'),)], rrows)
+
+        # cannot multiply None (default ToDecimal behavior) by a decimal
+        with self.assertRaises(TypeError):
+            rtypes, rrows = query.run_query(entries, options_map,
+                                          'SELECT decimal(getitem(commodity_meta('
+                                          + 'commodity(units(position))), "pcnt_bonds_us"))'
+                                          + '* number(convert(units(position), "USD"))')
+
+        rtypes, rrows = query.run_query(entries, options_map,
+                                        'SELECT decimal(getitem(commodity_meta(commodity'
+                                        + '(units(position))), "pcnt_bonds_us"), 0.0)'
+                                        + '* number(convert(units(position), "USD"))')
+        self.assertEqual([(D('0.00'),)], rrows)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
_Moved from: https://github.com/beancount/beancount/pull/692_

**Summary**

Adds `decimal(<str>)`, `decimal(<str>, <Decimal>)` and `round(<Decimal>, <int>)` functions to bean-query.

----
**Background:**

Portfolio balance check-in time - I set up my commodities as follows, and wanted to get a quick summary of US/non-US, stocks/bonds exposure.

```
2016-11-19 commodity INDX
    pcnt_stocks_us: 0.60
    pcnt_stocks_int: 0.40
```

This is *almost* usable out of the box, but `getitem(commodity_meta(<commodity>), <key>)` returns a `str`, so I can't multiply out the values. I worked around this by creating many rows with `group by` and then using Google Sheets to do the final calculations, but with these two functions a nice report portfolio allocation report can easily be done just with bean-query.

With these two functions, I can instead write a query like:

```
select
    sum(convert(position, 'USD')) as total_value,
    round(safediv(
        sum(getprice(commodity(units(position)), 'USD') * decimal(getitem(commodity_meta(commodity(units(position))), 'pcnt_stocks_us'), 0.0) * number(units(position))),
        sum(getprice(commodity(units(position)), 'USD') * number(units(position)))
    )*100.0, 2) as pcnt_value_us_stocks
    where account ~ 'Assets:Retirement' and commodity(units(position)) != 'USD'
```

----

**More Functions?**

As an aside, there are some convenience functions I can see adding, like `commodity_meta(<commodity>, <key>)` to simplify `getitem(commodity_meta(<commodity>), <key>)` , and I'd really love to be able to just do `commodity_meta(<position>, <key>)`.  If PRs for more Python-based functions for bean-query make sense for the v3 roadmap, what's the best way to handle proposing these convenience functions? PR with implementation, GitHub issue, Google Groups email?