### PR TITLE
Refactor implementation of BQL functions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -16,6 +16,7 @@ disable=
   no-self-use,
   no-value-for-parameter,
   redefined-argument-from-local,
+  redefined-builtin,
   redefined-outer-name,
   similarities,
   too-many-lines,

--- a/beanquery/query_compile_test.py
+++ b/beanquery/query_compile_test.py
@@ -107,13 +107,13 @@ class TestCompileAggregateChecks(unittest.TestCase):
         self.assertTrue(qc.is_aggregate(c_query))
 
         # Simple non-aggregate function.
-        c_query = qe.Length([qe.AccountColumn()])
+        c_query = qe.F('length', str)([qe.AccountColumn()])
         columns, aggregates = qc.get_columns_and_aggregates(c_query)
         self.assertEqual((1, 0), (len(columns), len(aggregates)))
         self.assertFalse(qc.is_aggregate(c_query))
 
         # Mix of column and aggregates (this is used to detect this illegal case).
-        c_query = qc.EvalAnd(qe.Length([qe.AccountColumn()]),
+        c_query = qc.EvalAnd(qe.F('length', str)([qe.AccountColumn()]),
                              qe.SumPosition([qe.PositionColumn()]))
         columns, aggregates = qc.get_columns_and_aggregates(c_query)
         self.assertEqual((1, 1), (len(columns), len(aggregates)))
@@ -352,7 +352,7 @@ class TestCompileSelect(CompileSelectBase):
         # Test the wildcard expansion.
         query = self.compile("SELECT length(account), account as a, date;")
         self.assertEqual(
-            [qc.EvalTarget(qe.Length([qe.AccountColumn()]), 'length_account', False),
+            [qc.EvalTarget(qe.F('length', str)([qe.AccountColumn()]), 'length_account', False),
              qc.EvalTarget(qe.AccountColumn(), 'a', False),
              qc.EvalTarget(qe.DateColumn(), 'date', False)],
             query.c_targets)

--- a/beanquery/query_env_test.py
+++ b/beanquery/query_env_test.py
@@ -6,9 +6,7 @@ import unittest
 from decimal import Decimal
 
 from beancount.core.number import D
-from beancount.core import inventory
 from beancount.core import position
-from beancount.core import amount
 from beancount.parser import parser
 from beanquery import query_compile as qc
 from beanquery import query_env as qe
@@ -19,45 +17,9 @@ class TestCompileDataTypes(unittest.TestCase):
 
     def test_compile_EvalLength(self):
         with self.assertRaises(qc.CompilationError):
-            qe.Length([qc.EvalConstant(17)])
-        c_length = qe.Length([qc.EvalConstant('testing')])
+            qe.F('length', str)([qc.EvalConstant(17)])
+        c_length = qe.F('length', str)([qc.EvalConstant('testing')])
         self.assertEqual(int, c_length.dtype)
-
-    def test_compile_EvalYear(self):
-        with self.assertRaises(qc.CompilationError):
-            qe.Year([qc.EvalConstant(17)])
-        c_year = qe.Year([qc.EvalConstant(datetime.date.today())])
-        self.assertEqual(int, c_year.dtype)
-
-    def test_compile_EvalMonth(self):
-        with self.assertRaises(qc.CompilationError):
-            qe.Month([qc.EvalConstant(17)])
-        c_month = qe.Month([qc.EvalConstant(datetime.date.today())])
-        self.assertEqual(int, c_month.dtype)
-
-    def test_compile_EvalDay(self):
-        with self.assertRaises(qc.CompilationError):
-            qe.Day([qc.EvalConstant(17)])
-        c_day = qe.Day([qc.EvalConstant(datetime.date.today())])
-        self.assertEqual(int, c_day.dtype)
-
-    def test_compile_EvalUnits(self):
-        with self.assertRaises(qc.CompilationError):
-            qe.UnitsPosition([qc.EvalConstant(17)])
-        with self.assertRaises(qc.CompilationError):
-            qe.UnitsPosition([qc.EvalConstant(inventory.Inventory())])
-        c_units = qe.UnitsPosition(
-            [qc.EvalConstant(position.Position.from_string('100 USD'))])
-        self.assertEqual(amount.Amount, c_units.dtype)
-
-    def test_compile_EvalCost(self):
-        with self.assertRaises(qc.CompilationError):
-            qe.CostPosition([qc.EvalConstant(17)])
-        with self.assertRaises(qc.CompilationError):
-            qe.CostPosition([qc.EvalConstant(inventory.Inventory())])
-        c_cost = qe.CostPosition([qc.EvalConstant(
-            position.Position.from_string('100 USD'))])
-        self.assertEqual(amount.Amount, c_cost.dtype)
 
     def test_compile_EvalSum(self):
         with self.assertRaises(qc.CompilationError):


### PR DESCRIPTION
Use a function decorator to build the function evaluator class and add the implementation to the BQL functions registry.

I haven't converted all BQL function definitions yet. It is tedious enough work that I would like to get feedback before converting the remaining ones. The data types are now passed explicitly to the decorator. They could be extracted from type annotations, but the code would not get shorter, and given the uncertain of the annotations implementation in future Python versions I would avoid to interact directly with them.