### PR TITLE
Refactor binary ops

### DIFF
--- a/beanquery/query_compile.py
+++ b/beanquery/query_compile.py
@@ -200,6 +200,25 @@ def _sub(x, y):
     return x - y
 
 
+@binaryop(query_parser.Add, [datetime.date, int], datetime.date)
+def _add_date_int(x, y):
+    return x + datetime.timedelta(days=y)
+
+
+@binaryop(query_parser.Add, [int, datetime.date], datetime.date)
+def _add_date_int(x, y):
+    return y + datetime.timedelta(days=x)
+
+
+@binaryop(query_parser.Sub, [datetime.date, int], datetime.date)
+def _sub_date_int(x, y):
+    return x - datetime.timedelta(days=y)
+
+
+@binaryop(query_parser.Sub, [datetime.date, datetime.date], int)
+def _sub_date_date(x, y):
+    return (x - y).days
+
 
 @binaryop(query_parser.Match, [str, str], bool)
 def _match(x, y):

--- a/beanquery/query_compile_test.py
+++ b/beanquery/query_compile_test.py
@@ -339,6 +339,32 @@ class CompileSelectBase(unittest.TestCase):
             raise
 
 
+class TestCompileFundamentals(CompileSelectBase):
+
+    def test_operaotors(self):
+        expr = self.compile("SELECT 1 + 1 AS expr")
+        self.assertEqual(expr, qc.EvalQuery(
+            [qc.EvalTarget(
+                qc.Operator(qp.Add, [
+                    qc.EvalConstant(1),
+                    qc.EvalConstant(1)
+                ]), 'expr', False)],
+            None, None, None, None, None, None, None, None))
+
+        expr = self.compile("SELECT 1 + meta('int') AS expr")
+        self.assertEqual(expr, qc.EvalQuery(
+            [qc.EvalTarget(
+                qc.Operator(qp.Add, [
+                    qc.EvalConstant(1),
+                    qe.Function('decimal', [
+                        qe.Function('meta', [
+                            qc.EvalConstant('int'),
+                        ]),
+                    ]),
+                ]), 'expr', False)],
+            None, None, None, None, None, None, None, None))
+
+
 class TestCompileSelect(CompileSelectBase):
 
     def test_compile_from(self):

--- a/beanquery/query_execute_test.py
+++ b/beanquery/query_execute_test.py
@@ -244,10 +244,14 @@ class TestFundamentals(QueryBase):
         self.assertResult("SELECT 1.0 + 1", Decimal(2))
         self.assertResult("SELECT 1.0 + 2.00", Decimal(3))
         self.assertError ("SELECT 1970-01-01 + 2022-04-01")
+        self.assertResult("SELECT 2022-04-01 + 1", datetime.date(2022, 4, 2))
+        self.assertResult("SELECT 1 + 2022-04-01", datetime.date(2022, 4, 2))
         # sub
         self.assertResult("SELECT 1 - 1", 0)
         self.assertResult("SELECT 1.0 - 1", Decimal(0))
         self.assertResult("SELECT 1.0 - 2.00", Decimal(-1))
+        self.assertResult("SELECT 2022-04-01 - 1", datetime.date(2022, 3, 31))
+        self.assertResult("SELECT 2022-04-01 - 2022-03-31", 1)
         self.assertError ("SELECT 1 - 2022-04-01")
         # mul
         self.assertResult("SELECT 2 * 2", 4)

--- a/beanquery/query_execute_test.py
+++ b/beanquery/query_execute_test.py
@@ -277,6 +277,11 @@ class TestFundamentals(QueryBase):
         # not
         self.assertResult("SELECT not TRUE", False)
 
+    def test_operators_type_inference(self):
+        self.assertResult("SELECT 1 + meta('int')", Decimal(2))
+        self.assertResult("SELECT 1 + meta('str3')", Decimal(4))
+        self.assertResult("SELECT meta('int') > 0", True)
+
     def test_functions(self):
         # round
         self.assertResult("SELECT round(1.2)", Decimal(1))

--- a/beanquery/types.py
+++ b/beanquery/types.py
@@ -2,6 +2,9 @@ class AnyType:
     """As written on the tin."""
     __slots__ = ()
 
+    # Used in the repr() of function and operators.
+    __name__ = '*'
+
     def __eq__(self, other):
         """Compares equal to any other type."""
         return isinstance(other, type)

--- a/beanquery/types.py
+++ b/beanquery/types.py
@@ -1,3 +1,7 @@
+import datetime
+import decimal
+
+
 class AnyType:
     """As written on the tin."""
     __slots__ = ()
@@ -25,8 +29,18 @@ def function_lookup(functions, name, operands):
     Returns:
       A EvalNode (or subclass) instance or None if the function was not found.
     """
-    signature = [operand.dtype for operand in operands]
+    intypes = [operand.dtype for operand in operands]
     for func in functions[name]:
-        if func.__intypes__ == signature:
+        if func.__intypes__ == intypes:
             return func
     return None
+
+
+# Map types to their BQL name. Used to find the name of the type cast funtion.
+MAP = {
+    bool: 'bool',
+    datetime.date: 'date',
+    decimal.Decimal: 'decimal',
+    int: 'int',
+    str: 'str',
+}


### PR DESCRIPTION
On one hand this is cool because it extends type checking in BQL resulting in query compile time errors rather than in runtime splats. On the other hand, metadata values are not types, and they cannot reasonably be. Therefore, this requires rewriting something like:
```
SELECT * WHERE entry_meta('foo') > 42
```
into
```
SELECT * WHERE decimal(entry_meta('foo')) > 42
```
Where `decimal` is a type casting function that need to be introduced along with similar type casting functions for all BQL types. Alternatively, the query compiler could in principle infer the type and introduce an implicit type conversion. I am not sure how complex this would turn out to be.