### PR TITLE
Switch from pytest to plain unittest for the CI jobs

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -19,6 +19,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.10'
-      - run: pip install -r requirements.txt click ply python-dateutil pytest coverage
-      - run: python -m coverage run --branch -m pytest beanquery/query_parser_test.py
+      - run: pip install -r requirements.txt click ply python-dateutil coverage
+      - run: python -m coverage run --branch -m unittest beanquery/query_parser_test.py
       - run: python -m coverage report --precision=2 --fail-under=100 beanquery/query_parser.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,5 +19,5 @@ jobs:
         if: ${{ matrix.beancount != '3.0' }}
       - run: pip install 'git+https://github.com/beancount/beancount#egg=beancount'
         if: ${{ matrix.beancount == '3.0' }}
-      - run: pip install click ply python-dateutil pytest
-      - run: python -m pytest beanquery
+      - run: pip install click ply python-dateutil
+      - run: python -m unittest discover -p '*_test.py' -s beanquery/


### PR DESCRIPTION
In this context pytest does not offer any advantage and getting rid of the dependency speeds up the jobs a tiny bit.