### PR TITLE
Generalize beanquery to work on more than Beancount ledgers

### DIFF
--- a/beanquery/query_execute.py
+++ b/beanquery/query_execute.py
@@ -456,3 +456,13 @@ def flatten_results(result_types, result_rows):
                     for name, result_type in result_types]
 
     return output_types, output_rows
+
+
+def execute_create_table(stmt):
+    from beanquery import tables
+    from beanquery import csvtable
+
+    import urllib.parse
+
+    handler = tables.SCHEMES.get(urllib.parse.urlparse(stmt.uri).scheme)
+    table = handler(stmt.name, stmt.uri, stmt.columns)

--- a/beanquery/query_execute.py
+++ b/beanquery/query_execute.py
@@ -273,10 +273,11 @@ def execute_query(query, entries, options_map):
 
     context = create_row_context(entries, options_map)
 
+    # FIXME!!
     # Filter the entries using the FROM clause.
-    filt_entries = (filter_entries(query.c_from, entries, options_map, context)
-                    if query.c_from is not None else
-                    entries)
+    # filt_entries = (filter_entries(query.c_from, entries, options_map, context)
+    #                 if query.c_from is not None else
+    #                 entries)
 
     # Dispatch between the non-aggregated queries and aggregated queries.
     c_where = query.c_where
@@ -288,20 +289,23 @@ def execute_query(query, entries, options_map):
     if query.group_indexes is None:
         # This is a non-aggregated query.
 
+        for context in query.table:
+            if c_where is None or c_where(context):
+                values = [c_expr(context) for c_expr in c_target_exprs]
+                rows.append(values)
+
         # Iterate over all the postings once.
-        for entry in misc_utils.filter_type(filt_entries, data.Transaction):
-            context.entry = entry
-            for posting in entry.postings:
-                context.posting = posting
-                if c_where is None or c_where(context):
-                    # Compute the balance.
-                    if uses_balance:
-                        context.balance.add_position(posting)
-
-                    # Evaluate all the values.
-                    values = [c_expr(context) for c_expr in c_target_exprs]
-
-                    rows.append(values)
+        # for entry in misc_utils.filter_type(filt_entries, data.Transaction):
+        #     context.entry = entry
+        #     for posting in entry.postings:
+        #         context.posting = posting
+        #         if c_where is None or c_where(context):
+        #             # Compute the balance.
+        #             if uses_balance:
+        #                 context.balance.add_position(posting)
+        #             # Evaluate all the values.
+        #             values = [c_expr(context) for c_expr in c_target_exprs]
+        #             rows.append(values)
     else:
         # This is an aggregated query.
 

--- a/beanquery/query_parser.py
+++ b/beanquery/query_parser.py
@@ -129,6 +129,12 @@ PivotBy = cmptuple('PivotBy', 'columns')
 #   name: A string, the name of the column to access.
 Column = cmptuple('Column', 'name')
 
+# A reference to a table.
+#
+# Attributes:
+#   name: The name of the table.
+Table = cmptuple('Table', 'name')
+
 # A function call.
 #
 # Attributes:
@@ -208,7 +214,7 @@ class Lexer:
 
     # List of valid tokens from the lexer.
     tokens = [
-        'ID', 'INTEGER', 'DECIMAL', 'STRING', 'DATE', 'COMMA', 'SEMI',
+        'ID', 'TABLEID', 'INTEGER', 'DECIMAL', 'STRING', 'DATE', 'COMMA', 'SEMI',
         'LPAREN', 'RPAREN', 'TILDE', 'EQ', 'NE', 'GT', 'GTE', 'LT', 'LTE',
         'ASTERISK', 'SLASH', 'PLUS', 'MINUS',
     ] + list(keywords)
@@ -226,6 +232,11 @@ class Lexer:
             token.value = utoken
         else:
             token.value = token.value.lower()
+        return token
+
+    def t_TABLEID(self, token):
+        r"\#[a-zA-Z_][a-zA-Z0-9_]*"
+        token.value = token.value[1:].lower()
         return token
 
     def t_STRING(self, token):
@@ -374,6 +385,12 @@ class SelectParser(Lexer):
             p[0] = From(p[2], p[3], p[4], p[5])
         else:
             p[0] = None
+
+    def p_from_table(self, p):
+        """
+        from_subselect : FROM TABLEID
+        """
+        p[0] = Table(p[2])
 
     def p_from_subselect(self, p):
         """

--- a/beanquery/shell.py
+++ b/beanquery/shell.py
@@ -536,6 +536,10 @@ class BQLShell(DispatchingShell):
         """
         return self.on_Select(balance)
 
+    def on_CreateTable(self, statement):
+        statement = query_compile.compile(statement, None, None, None)
+        query_execute.execute_create_table(statement)
+
     def help_targets(self):
         template = textwrap.dedent("""
 

--- a/beanquery/tables.py
+++ b/beanquery/tables.py
@@ -1,0 +1,48 @@
+from beanquery import query_env
+
+
+class Table:
+    columns = {}
+    functions = {}
+
+    def __iter__(self):
+        raise NotImplementedError
+
+    def get_column(self, name):
+        """Return a column accessor for the given named column.
+        Args:
+          name: A string, the name of the column to access.
+        """
+        col = self.columns[name]
+        if col is not None:
+            return col()
+
+        raise CompilationError(f'Invalid column name "{name}" in table "{self.name}')
+
+    def get_function(self, name, operands):
+        """Return a function accessor for the given named function.
+        Args:
+          name: A string, the name of the function to access.
+        """
+        func = types.function_lookup(self.functions, name, operands)
+        if func is not None:
+            return func(operands)
+
+        sig = '{}({})'.format(name, ', '.join(operand.dtype.__name__ for operand in operands))
+        raise CompilationError(f'Unknown function "{sig}" in {self.context_name}')
+
+
+class NullTable(Table):
+    functions = query_env.SIMPLE_FUNCTIONS
+
+    def __iter__(self):
+        yield from iter([None])
+
+
+TABLES = {
+     '_': NullTable(),
+}
+
+
+def get(name):
+    return TABLES.get(name)

--- a/beanquery/tables.py
+++ b/beanquery/tables.py
@@ -1,12 +1,24 @@
 from beanquery import query_env
 
+SCHEMES = {}
+
 
 class Table:
-    columns = {}
+    scheme = None
     functions = {}
+
+    def __init__(self):
+        self.columns = {}
 
     def __iter__(self):
         raise NotImplementedError
+
+    def __init_subclass__(cls):
+        SCHEMES[cls.scheme] = cls
+
+    @property
+    def wildcard_columns(self):
+        return self.columns.keys()
 
     def get_column(self, name):
         """Return a column accessor for the given named column.
@@ -46,3 +58,7 @@ TABLES = {
 
 def get(name):
     return TABLES.get(name)
+
+
+def register(name, table):
+    TABLES[name] = table


### PR DESCRIPTION
This is very incomplete and really not much yet, but at least it works as a calculator:
```
$ python -m beanquery /dev/null "SELECT 1+1 FROM #_"
a
-
2
```
Because of the BQL `FROM` clause existing syntax the `FROM #_` thing is to select the null table you get when there is no `FROM` clause in an SQL query. To disambiguate table names from field names that may form an expression in the `FROM` clause, table names need to start with `#`.

A ton of refactoring is at the horizon but I think I have a plan.