### PR TITLE
Remove partial support for the FLATTEN query option

### DIFF
--- a/beanquery/query_compile.py
+++ b/beanquery/query_compile.py
@@ -927,12 +927,10 @@ def compile_from(from_clause, environ):
 #     This list may refer to either aggregates or non-aggregates.
 #   limit: An optional integer used to cut off the number of result rows returned.
 #   distinct: An optional boolean that requests we should uniquify the result rows.
-#   flatten: An optional boolean that requests we should output a single posting
-#     row for each currency present in an accumulated and output inventory.
 EvalQuery = collections.namedtuple('EvalQuery', ('c_targets c_from c_where '
                                                  'group_indexes having_index '
                                                  'order_spec '
-                                                 'limit distinct flatten'))
+                                                 'limit distinct'))
 
 def compile_select(select, targets_environ, postings_environ, entries_environ):
     """Prepare an AST for a Select statement into a very rudimentary execution tree.
@@ -1006,8 +1004,7 @@ def compile_select(select, targets_environ, postings_environ, entries_environ):
                      having_index,
                      order_spec,
                      select.limit,
-                     select.distinct,
-                     select.flatten)
+                     select.distinct)
 
 
 def transform_journal(journal):
@@ -1038,7 +1035,7 @@ def transform_journal(journal):
     return query_parser.Select(cooked_select.targets,
                                journal.from_clause,
                                cooked_select.where_clause,
-                               None, None, None, None, None, None)
+                               None, None, None, None, None)
 
 
 def transform_balances(balances):
@@ -1068,7 +1065,7 @@ def transform_balances(balances):
                                balances.where_clause,
                                cooked_select.group_by,
                                cooked_select.order_by,
-                               None, None, None, None)
+                               None, None, None)
 
 
 # A compiled print statement, ready for execution.

--- a/beanquery/query_compile_test.py
+++ b/beanquery/query_compile_test.py
@@ -348,8 +348,8 @@ class TestCompileFundamentals(CompileSelectBase):
                 qc.Operator(qp.Add, [
                     qc.EvalConstant(1),
                     qc.EvalConstant(1)
-                ]), 'expr', False)],
-            None, None, None, None, None, None, None, None))
+                ]), 'expr', False)
+        ], None, None, None, None, None, None, None))
 
         expr = self.compile("SELECT 1 + meta('int') AS expr")
         self.assertEqual(expr, qc.EvalQuery([
@@ -361,8 +361,8 @@ class TestCompileFundamentals(CompileSelectBase):
                             qc.EvalConstant('int'),
                         ]),
                     ]),
-                ]), 'expr', False)],
-            None, None, None, None, None, None, None, None))
+                ]), 'expr', False)
+        ], None, None, None, None, None, None, None))
 
     def test_coalesce(self):
         expr = self.compile("SELECT coalesce(narration, str(date), '~') AS expr")
@@ -372,8 +372,8 @@ class TestCompileFundamentals(CompileSelectBase):
                     qe.NarrationColumn(),
                     qe.Function('str', [qe.DateColumn()]),
                     qc.EvalConstant('~'),
-                ]), 'expr', False)],
-            None, None, None, None, None, None, None, None))
+                ]), 'expr', False)
+        ], None, None, None, None, None, None, None))
 
         with self.assertRaises(qc.CompilationError):
             self.compile("SELECT coalesce(narration, date, 1)")
@@ -687,7 +687,7 @@ class TestTranslationJournal(CompileSelectBase):
     def test_journal(self):
         journal = self.parse("JOURNAL;")
         select = qc.transform_journal(journal)
-        self.assertEqual(
+        self.assertEqual(select,
             qp.Select([
                 qp.Target(qp.Column('date'), None),
                 qp.Target(qp.Column('flag'), None),
@@ -698,70 +698,68 @@ class TestTranslationJournal(CompileSelectBase):
                 qp.Target(qp.Column('account'), None),
                 qp.Target(qp.Column('position'), None),
                 qp.Target(qp.Column('balance'), None),
-            ], None, None, None, None, None, None, None, None),
-            select)
+            ],
+            None, None, None, None, None, None, None))
 
     def test_journal_with_account(self):
         journal = self.parse("JOURNAL 'liabilities';")
         select = qc.transform_journal(journal)
-        self.assertEqual(
-            qp.Select([
-                qp.Target(qp.Column('date'), None),
-                qp.Target(qp.Column('flag'), None),
-                qp.Target(qp.Function('maxwidth', [qp.Column('payee'),
-                                                   qp.Constant(48)]), None),
-                qp.Target(qp.Function('maxwidth', [qp.Column('narration'),
-                                                   qp.Constant(80)]), None),
-                qp.Target(qp.Column('account'), None),
-                qp.Target(qp.Column('position'), None),
-                qp.Target(qp.Column('balance'), None),
-            ],
-                      None,
-                      qp.Match(qp.Column('account'), qp.Constant('liabilities')),
-                      None, None, None, None, None, None),
-            select)
+        self.assertEqual(select, qp.Select([
+            qp.Target(qp.Column('date'), None),
+            qp.Target(qp.Column('flag'), None),
+            qp.Target(qp.Function('maxwidth', [
+                qp.Column('payee'),
+                qp.Constant(48)]), None),
+            qp.Target(qp.Function('maxwidth', [
+                qp.Column('narration'),
+                qp.Constant(80)]), None),
+            qp.Target(qp.Column('account'), None),
+            qp.Target(qp.Column('position'), None),
+            qp.Target(qp.Column('balance'), None),
+        ],
+        None,
+        qp.Match(qp.Column('account'), qp.Constant('liabilities')),
+        None, None, None, None, None))
 
     def test_journal_with_account_and_from(self):
         journal = self.parse("JOURNAL 'liabilities' FROM year = 2014;")
         select = qc.transform_journal(journal)
-        self.assertEqual(
-            qp.Select([
-                qp.Target(qp.Column('date'), None),
-                qp.Target(qp.Column('flag'), None),
-                qp.Target(qp.Function('maxwidth', [qp.Column('payee'),
-                                                   qp.Constant(48)]), None),
-                qp.Target(qp.Function('maxwidth', [qp.Column('narration'),
-                                                   qp.Constant(80)]), None),
-                qp.Target(qp.Column('account'), None),
-                qp.Target(qp.Column('position'), None),
-                qp.Target(qp.Column('balance'), None),
-            ],
-                      qp.From(qp.Equal(qp.Column('year'), qp.Constant(2014)),
-                              None, None, None),
-                      qp.Match(qp.Column('account'), qp.Constant('liabilities')),
-                      None, None, None, None, None, None),
-            select)
+        self.assertEqual(select, qp.Select([
+            qp.Target(qp.Column('date'), None),
+            qp.Target(qp.Column('flag'), None),
+            qp.Target(qp.Function('maxwidth', [
+                qp.Column('payee'),
+                qp.Constant(48)]), None),
+            qp.Target(qp.Function('maxwidth', [
+                qp.Column('narration'),
+                qp.Constant(80)]), None),
+            qp.Target(qp.Column('account'), None),
+            qp.Target(qp.Column('position'), None),
+            qp.Target(qp.Column('balance'), None),
+        ],
+        qp.From(qp.Equal(qp.Column('year'), qp.Constant(2014)), None, None, None),
+        qp.Match(qp.Column('account'), qp.Constant('liabilities')),
+        None, None, None, None, None))
 
     def test_journal_with_account_func_and_from(self):
         journal = self.parse("JOURNAL 'liabilities' AT cost FROM year = 2014;")
         select = qc.transform_journal(journal)
-        self.assertEqual(
-            qp.Select([
-                qp.Target(qp.Column('date'), None),
-                qp.Target(qp.Column('flag'), None),
-                qp.Target(qp.Function('maxwidth', [qp.Column('payee'),
-                                                   qp.Constant(48)]), None),
-                qp.Target(qp.Function('maxwidth', [qp.Column('narration'),
-                                                   qp.Constant(80)]), None),
-                qp.Target(qp.Column('account'), None),
-                qp.Target(qp.Function('cost', [qp.Column('position')]), None),
-                qp.Target(qp.Function('cost', [qp.Column('balance')]), None),
-            ],
-                      qp.From(qp.Equal(qp.Column('year'), qp.Constant(2014)),
-                              None, None, None),
-                      qp.Match(qp.Column('account'), qp.Constant('liabilities')),
-                      None, None, None, None, None, None),
-            select)
+        self.assertEqual(select, qp.Select([
+            qp.Target(qp.Column('date'), None),
+            qp.Target(qp.Column('flag'), None),
+            qp.Target(qp.Function('maxwidth', [
+                qp.Column('payee'),
+                qp.Constant(48)]), None),
+            qp.Target(qp.Function('maxwidth', [
+                qp.Column('narration'),
+                qp.Constant(80)]), None),
+            qp.Target(qp.Column('account'), None),
+            qp.Target(qp.Function('cost', [qp.Column('position')]), None),
+            qp.Target(qp.Function('cost', [qp.Column('balance')]), None),
+        ],
+        qp.From(qp.Equal(qp.Column('year'), qp.Constant(2014)), None, None, None),
+        qp.Match(qp.Column('account'), qp.Constant('liabilities')),
+        None, None, None, None, None))
 
 
 class TestTranslationBalance(CompileSelectBase):
@@ -775,46 +773,40 @@ class TestTranslationBalance(CompileSelectBase):
     def test_balance(self):
         balance = self.parse("BALANCES;")
         select = qc.transform_balances(balance)
-        self.assertEqual(
-            qp.Select([
-                qp.Target(qp.Column('account'), None),
-                qp.Target(qp.Function('sum', [qp.Column('position')]), None),
-                ], None, None, self.group_by, self.order_by,
-                      None, None, None, None),
-            select)
+        self.assertEqual(select, qp.Select([
+            qp.Target(qp.Column('account'), None),
+            qp.Target(qp.Function('sum', [
+                qp.Column('position')
+            ]), None),
+        ],
+        None, None, self.group_by, self.order_by, None, None, None))
 
     def test_balance_with_units(self):
         balance = self.parse("BALANCES AT cost;")
         select = qc.transform_balances(balance)
-        self.assertEqual(
-            qp.Select([
-                qp.Target(qp.Column('account'), None),
-                qp.Target(qp.Function('sum',
-                                      [qp.Function('cost',
-                                                   [qp.Column('position')])]), None)],
-                      None, None, self.group_by, self.order_by,
-                      None, None, None, None),
-            select)
+        self.assertEqual(select, qp.Select([
+            qp.Target(qp.Column('account'), None),
+            qp.Target(qp.Function('sum', [
+                qp.Function('cost', [
+                    qp.Column('position')
+                ])
+            ]), None)
+        ],
+        None, None, self.group_by, self.order_by, None, None, None))
 
     def test_balance_with_units_and_from(self):
         balance = self.parse("BALANCES AT cost FROM year = 2014;")
         select = qc.transform_balances(balance)
-        self.assertEqual(
-            qp.Select([
-                qp.Target(qp.Column('account'), None),
-                qp.Target(qp.Function('sum', [qp.Function('cost',
-                                                          [qp.Column('position')])]), None),
-                ],
-                      qp.From(qp.Equal(qp.Column('year'), qp.Constant(2014)),
-                              None, None, None),
-                      None,
-                      self.group_by,
-                      self.order_by,
-                      None, None, None, None),
-            select)
-
-
-class TestCompilePrint(CompileSelectBase):
+        self.assertEqual(select, qp.Select([
+            qp.Target(qp.Column('account'), None),
+            qp.Target(qp.Function('sum', [
+                qp.Function('cost', [
+                    qp.Column('position')
+                ])
+            ]), None),
+        ],
+        qp.From(qp.Equal(qp.Column('year'), qp.Constant(2014)), None, None, None),
+        None, self.group_by, self.order_by, None, None, None))
 
     def test_print(self):
         self.assertCompile(qc.EvalPrint(None), "PRINT;")
@@ -828,7 +820,3 @@ class TestCompilePrint(CompileSelectBase):
                         qc.EvalConstant(2014),
                     ]), None, None, None)),
             """PRINT FROM year = 2014;""")
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/beanquery/query_execute.py
+++ b/beanquery/query_execute.py
@@ -10,7 +10,6 @@ import itertools
 import operator
 
 from beancount.core import data
-from beancount.core import position
 from beancount.core import inventory
 from beancount.core import getters
 from beancount.core import display_context
@@ -398,57 +397,4 @@ def execute_query(query, entries, options_map):
     if query.limit is not None:
         result_rows = result_rows[:query.limit]
 
-    # Flatten inventories if requested.
-    if query.flatten:
-        result_types, result_rows = flatten_results(result_types, result_rows)
-
-    return (result_types, result_rows)
-
-
-def flatten_results(result_types, result_rows):
-    """Convert inventories in result types to have a row for each.
-
-    This routine will expand all result lines with an inventory into a new line
-    for each position.
-
-    Args:
-        result_types: A list of (name, data-type) item pairs.
-        result_rows: A list of ResultRow tuples of length and types described by
-          'result_types'.
-    Returns:
-        result_types: A list of (name, data-type) item pairs. There should be no
-          Inventory types anymore.
-        result_rows: A list of ResultRow tuples of length and types described by
-          'result_types'. All inventories from the input should have been converted
-          to Position types.
-    """
-    indexes = set(index
-                  for index, (name, result_type) in enumerate(result_types)
-                  if result_type is inventory.Inventory)
-    if not indexes:
-        return (result_types, result_rows)
-
-    # pylint: disable=invalid-name
-    ResultRow = type(result_rows[0])
-
-    # We have to make at least some conversions.
-    num_columns = len(result_types)
-    output_rows = []
-    for result_row in result_rows:
-        max_rows = max(len(result_row[icol]) for icol in indexes)
-        for irow in range(max_rows):
-            output_row = []
-            for icol in range(num_columns):
-                value = result_row[icol]
-                if icol in indexes:
-                    value = value[irow] if irow < len(value) else None
-                output_row.append(value)
-            output_rows.append(ResultRow._make(output_row))
-
-    # Convert the types.
-    output_types = [(name, (position.Position
-                            if result_type is inventory.Inventory
-                            else result_type))
-                    for name, result_type in result_types]
-
-    return output_types, output_rows
+    return result_types, result_rows

--- a/beanquery/query_execute_test.py
+++ b/beanquery/query_execute_test.py
@@ -1248,44 +1248,5 @@ class TestArithmeticFunctions(QueryBase):
             [(D("0"),)])
 
 
-
-class TestExecuteFlatten(QueryBase):
-
-    def test_flatten_results(self):
-        ## FIXME: We need some dedicated tests of flattening results.
-        pass
-
-    INPUT = """
-
-      plugin "beancount.plugins.auto_accounts"
-
-      2010-02-23 *
-        Assets:Something       5.00 USD
-        Assets:Something       2.00 CAD
-        Assets:Something       4 HOOL {531.20 USD}
-        Equity:Rest
-
-    """
-
-    @unittest.skip('FIXME: Bring this back in')
-    def test_flatten(self):
-        self.check_query(
-            self.INPUT,
-            """
-            SELECT account, sum(position)
-            WHERE account = 'Assets:Something'
-            GROUP BY account
-            FLATTEN;
-            """,
-            [
-                ('account', str),
-                ('sum_position', inventory.Inventory),
-                ],
-            [
-                ('Assets:Something',
-                 inventory.from_string("5.00 USD, 2.00 CAD, 4 HOOL {531.20 USD}")),
-                ])
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/beanquery/query_parser.py
+++ b/beanquery/query_parser.py
@@ -33,10 +33,9 @@ from beancount.utils.misc_utils import cmptuple
 #   pivot_by: An instance of 'PivotBy', or None if absent.
 #   limit: An integer, or None is absent.
 #   distinct: A boolean value (True), or None if absent.
-#   flatten: A boolean value (True), or None if absent.
 Select = collections.namedtuple(
     'Select', ('targets from_clause where_clause '
-               'group_by order_by pivot_by limit distinct flatten'))
+               'group_by order_by pivot_by limit distinct'))
 
 # A select query that produces final balances for accounts.
 # This is equivalent to
@@ -202,8 +201,8 @@ class Lexer:
     keywords = {
         'SELECT', 'AS', 'FROM', 'WHERE', 'OPEN', 'CLOSE', 'CLEAR', 'ON',
         'BALANCES', 'JOURNAL', 'PRINT', 'AT', 'GROUP', 'BY', 'HAVING',
-        'ORDER', 'DESC', 'ASC', 'PIVOT', 'LIMIT', 'FLATTEN', 'DISTINCT',
-        'AND', 'OR', 'NOT', 'IN', 'IS', 'TRUE', 'FALSE', 'NULL',
+        'ORDER', 'DESC', 'ASC', 'PIVOT', 'LIMIT', 'DISTINCT', 'AND',
+        'OR', 'NOT', 'IN', 'IS', 'TRUE', 'FALSE', 'NULL',
     }
 
     # List of valid tokens from the lexer.
@@ -331,9 +330,9 @@ class SelectParser(Lexer):
     def p_select_statement(self, p):
         """
         select_statement : SELECT distinct target_spec from_subselect where \
-                           group_by order_by pivot_by limit flatten
+                           group_by order_by pivot_by limit
         """
-        p[0] = Select(p[3], p[4], p[5], p[6], p[7], p[8], p[9], p[2], p[10])
+        p[0] = Select(p[3], p[4], p[5], p[6], p[7], p[8], p[9], p[2])
 
     def p_distinct(self, p):
         """
@@ -487,13 +486,6 @@ class SelectParser(Lexer):
               | LIMIT INTEGER
         """
         p[0] = p[2] if len(p) == 3 else None
-
-    def p_flatten(self, p):
-        """
-        flatten : empty
-                | FLATTEN
-        """
-        p[0] = True if p[1] == 'FLATTEN' else None
 
 
     precedence = [

--- a/beanquery/query_parser_test.py
+++ b/beanquery/query_parser_test.py
@@ -16,8 +16,7 @@ def Select(targets, from_clause=None, where_clause=None, **kwargs):
                     order_by=None,
                     pivot_by=None,
                     limit=None,
-                    distinct=None,
-                    flatten=None)
+                    distinct=None)
     defaults.update(kwargs)
     return qp.Select(**defaults)
 
@@ -476,14 +475,6 @@ class TestSelectOptions(QueryParserTestBase):
     def test_limit_present(self):
         self.assertParse(
             "SELECT * LIMIT 45;", Select(qp.Wildcard(), limit=45))
-
-    def test_flatten(self):
-        self.assertParse(
-            "SELECT * FLATTEN;", Select(qp.Wildcard(), flatten=True))
-
-    def test_limit_and_flatten(self):
-        self.assertParse(
-            "SELECT * LIMIT 1 FLATTEN;", Select(qp.Wildcard(), limit=1, flatten=True))
 
     def test_limit_empty(self):
         with self.assertRaises(qp.ParseError):


### PR DESCRIPTION
The implementation was broken and incomplete. It is not clear what to
do when two columns in the results set contain two inventory columns.
The FLATTEN query option also partially overlaps with the "expand"
option in the table renderer. It has been broken for quite some time
and there have not been many complaints. Just nuke it. If someone
comes up with a sensible design it will be easy to reinstate it.