### PR TITLE
compile: Implement constants folding

### DIFF
--- a/beanquery/query_compile_test.py
+++ b/beanquery/query_compile_test.py
@@ -344,11 +344,7 @@ class TestCompileFundamentals(CompileSelectBase):
     def test_operaotors(self):
         expr = self.compile("SELECT 1 + 1 AS expr")
         self.assertEqual(expr, qc.EvalQuery([
-            qc.EvalTarget(
-                qc.Operator(qp.Add, [
-                    qc.EvalConstant(1),
-                    qc.EvalConstant(1)
-                ]), 'expr', False)
+            qc.EvalTarget(qc.EvalConstant(2), 'expr', False)
         ], None, None, None, None, None, None, None))
 
         expr = self.compile("SELECT 1 + meta('int') AS expr")
@@ -820,3 +816,23 @@ class TestTranslationBalance(CompileSelectBase):
                         qc.EvalConstant(2014),
                     ]), None, None, None)),
             """PRINT FROM year = 2014;""")
+
+
+class TestCompileConstantsFolding(unittest.TestCase):
+
+    def compile(self, expr):
+        return qc.compile_expression(expr, qe.TargetsEnvironment())
+
+    def test_constants_folding(self):
+        # unary op
+        self.assertEqual(
+            self.compile(qp.Neg(qp.Constant(2))),
+            qc.EvalConstant(-2))
+        # binary op
+        self.assertEqual(
+            self.compile(qp.Add(qp.Constant(2), qp.Constant(2))),
+            qc.EvalConstant(4))
+        # funtion
+        self.assertEqual(
+            self.compile(qp.Function('root', [qp.Constant('Assets:Cash'), qp.Constant(1)])),
+            qc.EvalConstant('Assets'))

--- a/beanquery/query_env.py
+++ b/beanquery/query_env.py
@@ -43,6 +43,7 @@ def function(intypes, outtype, pass_context=False, name=None):
     def decorator(func):
         class Func(query_compile.EvalFunction):
             __intypes__ = intypes
+            pure = not pass_context
             def __init__(self, operands):
                 super().__init__(operands, outtype)
             def __call__(self, context):


### PR DESCRIPTION
This generalizes and improves what was previously done only for the
negation operator. Applying this to functions requires marking
functions that depend on the context and do not apply the optimization
to these.