### PR TITLE
Drop python-dateutil dependency

### DIFF
--- a/beanquery/parser/__init__.py
+++ b/beanquery/parser/__init__.py
@@ -1,7 +1,6 @@
 import datetime
 import decimal
 
-import dateutil.parser
 import tatsu
 
 from . import ast

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 beancount >=2.3.4
 click >7.0
 tatsu >=5.7.4, <5.8.0
-python-dateutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ install_requires =
     beancount >=2.3.4
     click >7.0
     tatsu >=5.7.4, <5.8.0
-    python-dateutil
 python_requires = >=3.8
 
 [options.entry_points]


### PR DESCRIPTION
With the support for #"..." date literals removed, there are no more uses.