### PR TITLE
Restructure API

### DIFF
--- a/beanquery/__init__.py
+++ b/beanquery/__init__.py
@@ -1,4 +1,41 @@
-"""Transaction and postings filtering syntax parser.
-"""
-__copyright__ = "Copyright (C) 2014-2017  Martin Blais"
-__license__ = "GNU GPLv2"
+import importlib
+
+from urllib.parse import urlparse
+
+from . import parser
+from . import query_compile
+from . import query_execute
+from . import tables
+
+from .parser import ParseError  # noqa: F401
+from .query_compile import CompilationError  # noqa: F401
+
+
+def connect(uri):
+    return Connection(uri)
+
+
+class Connection:
+    def __init__(self, uri=None):
+        self.tables = {None: tables.NullTable()}
+        self.options = {}
+        self.errors = []
+        if uri is not None:
+            self.attach(uri)
+
+    def attach(self, uri):
+        scheme = urlparse(uri).scheme
+        source = importlib.import_module(f'beanquery.sources.{scheme}')
+        source.attach(self, uri)
+
+    def parse(self, statement):
+        return parser.parse(statement)
+
+    def compile(self, statement):
+        return query_compile.compile(self, statement)
+
+    def execute(self, statement):
+        if not isinstance(statement, parser.ast.Node):
+            statement = parser.parse(statement)
+        query = query_compile.compile(self, statement)
+        return query_execute.execute_query(query)

--- a/beanquery/parser/ast.py
+++ b/beanquery/parser/ast.py
@@ -49,7 +49,6 @@ def node(name, fields):
         name,
         [*fields.split(), ('parseinfo', None, dataclasses.field(default=None, compare=False, repr=False))],
         bases=(Node,),
-        frozen=True,
         **({'slots': True} if sys.version_info[:2] >= (3, 10) else {}))
 
 

--- a/beanquery/query.py
+++ b/beanquery/query.py
@@ -3,12 +3,9 @@
 __copyright__ = "Copyright (C) 2015-2017  Martin Blais"
 __license__ = "GNU GPLv2"
 
-from beanquery import parser
-from beanquery import query_compile
-from beanquery import query_env
-from beanquery import query_execute
+from beanquery import Connection
 from beanquery import numberify as numberify_lib
-
+from beanquery.sources.beancount import add_beancount_tables
 
 def run_query(entries, options_map, query, *format_args, numberify=False):
     """Compile and execute a query, return the result types and rows.
@@ -29,20 +26,14 @@ def run_query(entries, options_map, query, *format_args, numberify=False):
     """
 
     # Register tables.
-    query_compile.TABLES['entries'] = query_env.EntriesTable(entries, options_map)
-    query_compile.TABLES['postings'] = query_env.PostingsTable(entries, options_map)
+    ctx = Connection()
+    add_beancount_tables(ctx, entries, [], options_map)
 
     # Apply formatting to the query.
     formatted_query = query.format(*format_args)
 
-    # Parse the statement.
-    statement = parser.parse(formatted_query)
-
-    # Compile the SELECT statement.
-    c_query = query_compile.compile(statement)
-
     # Execute it to obtain the result rows.
-    rtypes, rrows = query_execute.execute_query(c_query)
+    rtypes, rrows = ctx.execute(formatted_query)
 
     # Numberify the results, if requested.
     if numberify:

--- a/beanquery/query_compile_test.py
+++ b/beanquery/query_compile_test.py
@@ -5,6 +5,7 @@ import datetime
 import unittest
 from decimal import Decimal
 
+from beanquery import Connection
 from beanquery import query_compile as qc
 from beanquery import query_env as qe
 from beanquery import parser
@@ -166,10 +167,10 @@ class CompileSelectBase(unittest.TestCase):
 
     maxDiff = 8192
 
-    @classmethod
-    def setUpClass(cls):
-        qc.TABLES['entries'] = qe.EntriesTable(None, None)
-        qc.TABLES['postings'] = qe.PostingsTable(None, None)
+    def setUp(self):
+        self.ctx = Connection()
+        self.ctx.tables['entries'] = qe.EntriesTable(None, None)
+        self.ctx.tables['postings'] = qe.PostingsTable(None, None)
 
     def compile(self, query):
         """Parse one query and compile it.
@@ -179,8 +180,7 @@ class CompileSelectBase(unittest.TestCase):
         Returns:
           The AST.
         """
-        statement = parser.parse(query)
-        c_query = qc.compile(statement)
+        c_query = self.ctx.compile(self.ctx.parse(query))
         if isinstance(c_query, ast.Select):
             self.assertSelectInvariants(c_query)
         return c_query

--- a/beanquery/shell.py
+++ b/beanquery/shell.py
@@ -325,7 +325,7 @@ class BQLShell(DispatchingShell):
     def parse(self, line, default_close_date=None):
         statement = parser.parse(line)
         if (isinstance(statement, parser.ast.Select) and
-            statement.from_clause is not None and
+            isinstance(statement.from_clause, parser.ast.From) and
             not statement.from_clause.close):
             statement.from_clause.close = default_close_date
         return statement

--- a/beanquery/shell_test.py
+++ b/beanquery/shell_test.py
@@ -13,6 +13,7 @@ from beancount import loader
 from beancount.utils import test_utils
 
 from beanquery import shell
+from beanquery.sources.beancount import add_beancount_tables
 
 
 @functools.lru_cache(None)
@@ -122,8 +123,10 @@ def runshell(function):
     """Decorate a function to run the shell and return the output."""
     def wrapper(self):
         with test_utils.capture('stdout') as stdout:
-            shell_obj = shell.BQLShell(False, load, sys.stdout)
-            shell_obj.do_reload()
+            shell_obj = shell.BQLShell(False, None, sys.stdout)
+            entries, errors, options = load()
+            add_beancount_tables(shell_obj.context, entries, errors, options)
+            shell_obj._extract_queries(entries)
             shell_obj.onecmd(function.__doc__)
         return function(self, stdout.getvalue())
     return wrapper

--- a/beanquery/sources/beancount.py
+++ b/beanquery/sources/beancount.py
@@ -1,0 +1,16 @@
+from urllib.parse import urlparse
+from beancount import loader
+from beanquery import query_env
+
+
+def add_beancount_tables(context, entries, errors, options):
+    for table in query_env.EntriesTable, query_env.PostingsTable:
+        context.tables[table.name] = table(entries, options)
+    context.options.update(options)
+    context.errors.extend(errors)
+
+
+def attach(context, uri):
+    filename = urlparse(uri).path
+    entries, errors, options = loader.load_file(filename)
+    add_beancount_tables(context, entries, errors, options)


### PR DESCRIPTION
``beanquery.connect()`` becomes the main entry point. It takes an URI pointing to a data source and returns a Connection() class with an ``execute()`` method that takes a query string and returns the query results.  The only data source scheme defined so far is ``beancount:`` which is expected to be followed by the path to a Beancount ledger.

This continues the effort toward the generalization of beanquery to work with data sources other than beancount and toward an API somehow similar to the Python's DB-API 2.0.

The main entry point of the old API (beanquery.query.run_query() aka beancount.query.run_query() before the project split) is preserved for backward compatibility.  As no other interface was clearly meant as public API, no particular effort has been put in preserving backward compatibility for other functions or classes.