### PR TITLE
parser, shell: Revisit default close date implementation

### DIFF
--- a/beanquery/parser/__init__.py
+++ b/beanquery/parser/__init__.py
@@ -51,8 +51,6 @@ class BQLSemantics:
     def from_(self, value, typename):
         if value['expression'] is None and value['open'] is None and value['close'] is None and value['clear_'] is None:
             self._ctx._error('Empty FROM expression is not allowed')  # pylint: disable=protected-access
-        if value['close'] is None:
-            value['close'] = self.default_close_date
         return self._default(value, typename)
 
     def _default(self, value, typename=None):

--- a/beanquery/parser/bql.ebnf
+++ b/beanquery/parser/bql.ebnf
@@ -36,7 +36,7 @@ subselect
 
 from::From
     = expression:[expression]
-      ['OPEN' ('ON' open:date | {} open:`True`)]
+      ['OPEN' 'ON' open:date]
       ['CLOSE' ('ON' close:date | {} close:`True`)]
       ['CLEAR' clear:`True`]
     ;

--- a/beanquery/parser/parser.py
+++ b/beanquery/parser/parser.py
@@ -236,30 +236,9 @@ class BQLParser(Parser):
         self.name_last_node('expression')
         with self._optional():
             self._token('OPEN')
-            with self._group():
-                with self._choice():
-                    with self._option():
-                        self._token('ON')
-                        self._date_()
-                        self.name_last_node('open')
-
-                        self._define(
-                            ['open'],
-                            []
-                        )
-                    with self._option():
-                        self._empty_closure()
-                        self._constant(True)
-                        self.name_last_node('open')
-
-                        self._define(
-                            ['open'],
-                            []
-                        )
-                    self._error(
-                        'expecting one of: '
-                        "'ON'"
-                    )
+            self._token('ON')
+            self._date_()
+            self.name_last_node('open')
 
             self._define(
                 ['open'],

--- a/beanquery/shell.py
+++ b/beanquery/shell.py
@@ -288,7 +288,11 @@ class DispatchingShell(cmd.Cmd):
           default_close_date: A datetimed.date instance, the default close date.
         """
         try:
-            statement = self.parser.parse(line, default_close_date=default_close_date)
+            statement = self.parser.parse(line)
+            if (isinstance(statement, parser.ast.Select) and
+                statement.from_clause is not None and
+                not statement.from_clause.close):
+                statement.from_clause.close = default_close_date
             self.dispatch(statement)
         except Exception as exc:
             print(render_exception(exc), file=sys.stderr)


### PR DESCRIPTION
Move default close date implementation for queries stored in the ledger from the query parse to the shell.  This allow to remove the special handling from generic code.