### PR TITLE
env: Return NULL on division by zero

### DIFF
--- a/beanquery/query_compile.py
+++ b/beanquery/query_compile.py
@@ -150,14 +150,6 @@ class EvalBinaryOp(EvalNode):
         return f'{self.__class__.__name__}({self.left!r}, {self.right!r})'
 
 
-# Note: We ought to implement implicit type promotion here,
-# e.g., int -> float -> Decimal.
-
-# Note(2): This does not support multiplication on Amount, Position, Inventory.
-# We need to rewrite the evaluator to support types in order to do this
-# properly.
-
-
 def unaryop(op, intypes, outtype, nullsafe=False):
     def decorator(func):
         class Op(EvalUnaryOp if nullsafe else EvalUnaryOpSafe):

--- a/beanquery/query_compile.py
+++ b/beanquery/query_compile.py
@@ -219,11 +219,15 @@ def mul_(x, y):
 @binaryop(ast.Div, [Decimal, int], Decimal)
 @binaryop(ast.Div, [int, Decimal], Decimal)
 def div_(x, y):
+    if y == 0:
+        return None
     return x / y
 
 
 @binaryop(ast.Div, [int, int], Decimal)
 def div_int(x, y):
+    if y == 0:
+        return None
     return Decimal(x) / y
 
 
@@ -232,6 +236,8 @@ def div_int(x, y):
 @binaryop(ast.Mod, [int, Decimal], Decimal)
 @binaryop(ast.Mod, [Decimal, Decimal], Decimal)
 def mod_(x, y):
+    if y == 0:
+        return None
     return x % y
 
 

--- a/beanquery/query_compile.py
+++ b/beanquery/query_compile.py
@@ -189,12 +189,12 @@ def neg_(x):
     return -x
 
 
-@unaryop(ast.IsNull, [object], bool, nullsafe=True)
+@unaryop(ast.IsNull, [types.Any], bool, nullsafe=True)
 def null(x):
     return x is None
 
 
-@unaryop(ast.IsNotNull, [object], bool, nullsafe=True)
+@unaryop(ast.IsNotNull, [types.Any], bool, nullsafe=True)
 def not_null(x):
     return x is not None
 

--- a/beanquery/query_execute_test.py
+++ b/beanquery/query_execute_test.py
@@ -2,7 +2,6 @@ __copyright__ = "Copyright (C) 2014-2017  Martin Blais"
 __license__ = "GNU GPLv2"
 
 import datetime
-import decimal
 import io
 import unittest
 import textwrap
@@ -233,6 +232,9 @@ class TestFundamentals(QueryBase):
         self.assertResult("SELECT 4.0 / 2", Decimal(2))
         self.assertResult("SELECT 4 / 2.0", Decimal(2))
         self.assertResult("SELECT 4.0 / 2.0", Decimal(2))
+        self.assertResult("SELECT 4 / 0", None, Decimal)
+        self.assertResult("SELECT 4.0 / 0", None, Decimal)
+        self.assertResult("SELECT 4 / 0.0", None, Decimal)
 
         # mod
         self.assertResult("SELECT 3 % 2", 1)
@@ -1194,18 +1196,16 @@ class TestArithmeticFunctions(QueryBase):
             [('result', Decimal)],
             [(D("2.50"),)])
 
-        # Test dbz, should fail result query.
-        with self.assertRaises(decimal.DivisionByZero):
-            self.check_query(
-                """
-                  2010-02-23 *
-                    Assets:Something       5.00 USD
-                """,
-                """
-                  SELECT number / 0 as result;
-                """,
-                [('result', Decimal)],
-                [(D("2.50"),)])
+        self.check_query(
+            """
+              2010-02-23 *
+                Assets:Something       5.00 USD
+            """,
+            """
+              SELECT number / 0 as result;
+            """,
+            [('result', Decimal)],
+            [(None,)])
 
     def test_safe_div(self):
         self.check_query(

--- a/beanquery/query_execute_test.py
+++ b/beanquery/query_execute_test.py
@@ -265,8 +265,12 @@ class TestFundamentals(QueryBase):
         self.assertResult("SELECT not meta('missing')", True)
 
         # is null
+        self.assertResult("SELECT date IS NULL", False)
         self.assertResult("SELECT meta('missing') IS NULL", True)
         self.assertResult("SELECT meta('int') IS NULL", False)
+
+        # is not null
+        self.assertResult("SELECT date IS NOT NULL", True)
         self.assertResult("SELECT meta('missing') IS NOT NULL", False)
         self.assertResult("SELECT meta('int') IS NOT NULL", True)
 


### PR DESCRIPTION
Following the SQL standard, do not raise an exception on division by zero but return NULL instead. This makes the ``safe_div()`` BQL function obsolete.