### PR TITLE
Add getitem and getattr

### DIFF
--- a/beanquery/parser/ast.py
+++ b/beanquery/parser/ast.py
@@ -167,6 +167,8 @@ Column = node('Column', 'name')
 #     evaluate. This is possibly an empty list.
 Function = node('Function', 'fname operands')
 
+Attribute = node('Attribute', 'operand name')
+
 Subscript = node('Subscript', 'operand key')
 
 # A constant node.

--- a/beanquery/parser/ast.py
+++ b/beanquery/parser/ast.py
@@ -167,6 +167,8 @@ Column = node('Column', 'name')
 #     evaluate. This is possibly an empty list.
 Function = node('Function', 'fname operands')
 
+Subscript = node('Subscript', 'operand key')
+
 # A constant node.
 #
 # Attributes:

--- a/beanquery/parser/bql.ebnf
+++ b/beanquery/parser/bql.ebnf
@@ -206,18 +206,28 @@ unary
     =
     | uplus
     | uminus
-    | literal
+    | primary
     ;
 
 uplus
-    = '+' @:literal
+    = '+' @:atom
     ;
 
 uminus::Neg::UnaryOp
     = '-' operand:factor
     ;
 
-literal
+primary
+    =
+    | subscript
+    | atom
+    ;
+
+subscript::Subscript
+    = operand:primary '[' key:string ']'
+    ;
+
+atom
     =
     | select
     | function
@@ -235,7 +245,7 @@ column::Column
     = name:identifier
     ;
 
-value
+literal
     =
     | date
     | decimal
@@ -246,11 +256,11 @@ value
     ;
 
 constant::Constant
-    = value:(value | list)
+    = value:(literal | list)
     ;
 
 list
-    = '(' &( value ',') @:','.{ (value | ()) }+ ')'
+    = '(' &( literal ',') @:','.{ (literal | ()) }+ ')'
     ;
 
 @name

--- a/beanquery/parser/bql.ebnf
+++ b/beanquery/parser/bql.ebnf
@@ -219,8 +219,13 @@ uminus::Neg::UnaryOp
 
 primary
     =
+    | attribute
     | subscript
     | atom
+    ;
+
+attribute::Attribute
+    = operand:primary '.' name:identifier
     ;
 
 subscript::Subscript

--- a/beanquery/parser/parser.py
+++ b/beanquery/parser/parser.py
@@ -846,8 +846,8 @@ class BQLParser(Parser):
                 self._primary_()
             self._error(
                 'expecting one of: '
-                "'+' '-' <atom> <primary> <subscript>"
-                '<uminus> <uplus>'
+                "'+' '-' <atom> <attribute> <primary>"
+                '<subscript> <uminus> <uplus>'
             )
 
     @tatsumasu()
@@ -872,15 +872,31 @@ class BQLParser(Parser):
     def _primary_(self):  # noqa
         with self._choice():
             with self._option():
+                self._attribute_()
+            with self._option():
                 self._subscript_()
             with self._option():
                 self._atom_()
             self._error(
                 'expecting one of: '
-                "'SELECT' <atom> <column> <constant>"
-                '<function> <primary> <select>'
+                "'SELECT' <atom> <attribute> <column>"
+                '<constant> <function> <primary> <select>'
                 '<subscript>'
             )
+
+    @tatsumasu('Attribute')
+    @nomemo
+    def _attribute_(self):  # noqa
+        self._primary_()
+        self.name_last_node('operand')
+        self._token('.')
+        self._identifier_()
+        self.name_last_node('name')
+
+        self._define(
+            ['name', 'operand'],
+            []
+        )
 
     @tatsumasu('Subscript')
     @nomemo
@@ -1279,6 +1295,9 @@ class BQLSemantics:
         return ast
 
     def primary(self, ast):  # noqa
+        return ast
+
+    def attribute(self, ast):  # noqa
         return ast
 
     def subscript(self, ast):  # noqa

--- a/beanquery/query_env.py
+++ b/beanquery/query_env.py
@@ -922,6 +922,11 @@ def links(context):
     return context.entry.links
 
 
+@column(dict)
+def meta(context):
+    return context.entry.meta
+
+
 class PostingsTable(EntriesTable):
     name = 'postings'
     columns = EntriesTable.columns.copy()
@@ -1080,6 +1085,15 @@ def balance(context):
     context.balance.add_position(context.posting)
     return copy.copy(context.balance)
 
+
+@column(dict)
+def meta(context):
+    return context.posting.meta
+
+
+@column(EntriesTable)
+def entry(context):
+    return context
 
 
 # Backward compatibility definitions for use in tests. These work

--- a/beanquery/query_execute_test.py
+++ b/beanquery/query_execute_test.py
@@ -311,6 +311,20 @@ class TestFundamentals(QueryBase):
         self.assertResult("SELECT COUNT(NULL)", 0)
         self.assertResult("SELECT COUNT(meta('missing'))", 0)
 
+    def test_getitem(self):
+        self.assertResult("SELECT meta['lineno']", 6, object)
+        self.assertResult("SELECT 1 + meta['lineno']", Decimal('7'))
+        self.assertResult("SELECT meta['filename']", '<string>', object)
+        self.assertResult("SELECT meta['missing']", None, object)
+        self.assertError ("SELECT position['foo']")
+
+    def test_getatrr(self):
+        self.assertResult("SELECT entry.flag", '*')
+        self.assertResult("SELECT int(entry.meta['lineno'])", 5)
+        self.assertError ("SELECT entry.foo")
+        self.assertError ("SELECT position.foo")
+
+
 class TestFilterEntries(CommonInputBase, QueryBase):
 
     @staticmethod

--- a/beanquery/query_render.py
+++ b/beanquery/query_render.py
@@ -124,14 +124,8 @@ class BoolRenderer(ColumnRenderer):
         return ('TRUE' if value else 'FALSE')
 
 
-class StringRenderer(ColumnRenderer):
+class StringRenderer(ObjectRenderer):
     dtype = str
-
-    def update(self, value):
-        self.maxwidth = max(self.maxwidth, len(value))
-
-    def format(self, value):
-        return value
 
 
 class SetRenderer(ColumnRenderer):
@@ -158,15 +152,9 @@ class DateRenderer(ColumnRenderer):
         return value.strftime('%Y-%m-%d')
 
 
-class IntRenderer(ColumnRenderer):
+class IntRenderer(ObjectRenderer):
     dtype = int
     align = Align.RIGHT
-
-    def update(self, value):
-        self.maxwidth = max(self.maxwidth, len(str(value)))
-
-    def format(self, value):
-        return str(value)
 
 
 class DecimalRenderer(ColumnRenderer):

--- a/beanquery/query_render.py
+++ b/beanquery/query_render.py
@@ -114,6 +114,10 @@ class ObjectRenderer(ColumnRenderer):
         return str(value)
 
 
+class DictRenderer(ObjectRenderer):
+    dtype = dict
+
+
 class BoolRenderer(ColumnRenderer):
     dtype = bool
 

--- a/beanquery/tables.py
+++ b/beanquery/tables.py
@@ -1,4 +1,7 @@
-class Table:
+from . import types
+
+
+class Table(types.Structure):
     columns = {}
     name = None
 

--- a/beanquery/types.py
+++ b/beanquery/types.py
@@ -28,6 +28,11 @@ class AsteriskType:
 Asterisk = AsteriskType()
 
 
+class Structure:
+    """Base class for structured data types."""
+    pass
+
+
 def function_lookup(functions, name, operands):
     """Lookup a BQL function implementation.
 


### PR DESCRIPTION
This allows to deprecate the `entry_meta()` and `meta()` functions:
```
  SELECT entry_meta('foo')
```
becomes
```
  SELECT entry.meta['foo']
```
This will allow to deprecate and eventually remove some BQL function
that need access to "hidden" context and that do not really belong in
a SQL-like data model.