### PR TITLE
Implement most of the DB-API 2.0 specification

### DIFF
--- a/beanquery/cursor.py
+++ b/beanquery/cursor.py
@@ -1,0 +1,154 @@
+from operator import attrgetter
+from typing import Sequence
+
+from . import types
+from . import parser
+from . import query_compile
+from . import query_execute
+
+
+class Column(Sequence):
+    __module__ = 'beanquery'
+
+    def __init__(self, name, datatype):
+        self._name = name
+        self._type = datatype
+
+    _vars = tuple(attrgetter(name) for name in 'name type_code display_size internal_size precision scale null_ok'.split())
+
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            return tuple(self) == tuple(other)
+        if isinstance(other, tuple):
+            # Used in tests.
+            return (self._name, self._type) == other
+        return NotImplemented
+
+    def __repr__(self):
+        return f'{self.__module__}.{self.__class__.__name__}({self._name!r}, {types.name(self._type)})'
+
+    def __len__(self):
+        return 7
+
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            return tuple(getter(self) for getter in self._vars(key))
+        return self._vars[key](self)
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def datatype(self):
+        # Extension to the DB-API.
+        return self._type
+
+    @property
+    def type_code(self):
+        # The DB-API specification is vague on this point, but other
+        # database connection libraries expose this as an int. It does
+        # not make much sense to keep a mapping between int type code
+        # and actual types, thus just return the hash of the type
+        # object.
+        return hash(self._type)
+
+    @property
+    def display_size(self):
+        return None
+
+    @property
+    def internal_size(self):
+        return None
+
+    @property
+    def precision(self):
+        return None
+
+    @property
+    def scale(self):
+        return None
+
+    @property
+    def null_ok(self):
+        return None
+
+
+class Cursor:
+    def __init__(self, connection):
+        self._context = connection
+        self._description = None
+        self._rows = None
+        self._pos = 0
+        self.arraysize = 1
+
+    @property
+    def connection(self):
+        return self._context
+
+    def execute(self, query, params=None):
+        if not isinstance(query, parser.ast.Node):
+            query = parser.parse(query)
+        query = query_compile.compile(self._context, query)
+        description, rows = query_execute.execute_query(query)
+        self._description = description
+        self._rows = rows
+        self._pos = 0
+        return self
+
+    def executemany(self, query, params=None):
+        for p in params:
+            self.execute(query, p)
+
+    @property
+    def description(self):
+        return self._description
+
+    @property
+    def rowcount(self):
+        return len(self._rows) if self._rows is not None else -1
+
+    @property
+    def rownumber(self):
+        return self._pos
+
+    def fetchone(self):
+        # This implementation pops items from the front of the results
+        # rows list and is thus not efficient, especially for large
+        # results sets.
+        if self._rows is None or not len(self._rows):
+            return None
+        self._pos += 1
+        return self._rows.pop(0)
+
+    def fetchmany(self, size=None):
+        if self._rows is None:
+            return []
+        n = size if size is not None else self.arraysize
+        rows = self._rows[:n]
+        self._rows = self._rows[n:]
+        self._pos += len(rows)
+        return rows
+
+    def fetchall(self):
+        if self._rows is None:
+            return []
+        rows = self._rows
+        self._rows = []
+        self._pos += len(rows)
+        return rows
+
+    def close(self):
+        # Required by the DB-API.
+        pass
+
+    def setinputsizes(self, sizes):
+        # Required by the DB-API.
+        pass
+
+    def setoutputsize(self, size, column=None):
+        # Required by the DB-API.
+        pass
+
+    def __iter__(self):
+        return iter(self._rows if self._rows is not None else [])

--- a/beanquery/cursor_test.py
+++ b/beanquery/cursor_test.py
@@ -1,0 +1,82 @@
+import unittest
+import sqlite3
+
+import beanquery
+from beanquery.tests import tables
+
+
+class APITests:
+    def test_description(self):
+        curs = self.conn.cursor()
+        self.assertIsNone(curs.description)
+        curs.execute(f'SELECT x FROM {self.table} WHERE x = 0')
+        self.assertEqual([c[0] for c in curs.description], ['x'])
+        column = curs.description[0]
+        self.assertEqual(len(column), 7)
+
+    def test_cursor_not_initialized(self):
+        curs = self.conn.cursor()
+        self.assertIsNone(curs.fetchone())
+        self.assertEqual(curs.fetchmany(), [])
+        self.assertEqual(curs.fetchall(), [])
+
+    def test_cursor_fetchone(self):
+        curs = self.conn.cursor()
+        curs.execute(f'SELECT x FROM {self.table} WHERE x < 2')
+        row = curs.fetchone()
+        self.assertEqual(row, (0, ))
+        row = curs.fetchone()
+        self.assertEqual(row, (1, ))
+        row = curs.fetchone()
+        self.assertIsNone(row)
+
+    def test_cursor_fetchall(self):
+        curs = self.conn.cursor()
+        curs.execute(f'SELECT x FROM {self.table} WHERE x < 2')
+        rows = curs.fetchall()
+        self.assertEqual(rows, [(0, ), (1, )])
+        rows = curs.fetchall()
+        self.assertEqual(rows, [])
+
+    def test_cursor_fethmany(self):
+        curs = self.conn.cursor()
+        curs.execute(f'SELECT x FROM {self.table} WHERE x < 2')
+        rows = curs.fetchmany()
+        self.assertEqual(rows, [(0, )])
+        rows = curs.fetchmany()
+        self.assertEqual(rows, [(1, )])
+        rows = curs.fetchmany()
+        self.assertEqual(rows, [])
+
+    def test_cursor_iterator(self):
+        curs = self.conn.cursor()
+        o = object()
+        row = next(iter(curs), o)
+        self.assertIs(row, o)
+        curs = self.conn.cursor()
+        curs.execute(f'SELECT x FROM {self.table} WHERE x < 2')
+        iterator = iter(curs)
+        row = next(iterator)
+        self.assertEqual(row, (0, ))
+        row = next(iterator)
+        self.assertEqual(row, (1, ))
+        row = next(iterator, o)
+        self.assertIs(row, o)
+
+
+class TestSQLite(APITests, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.table = 'test'
+        cls.conn = sqlite3.connect(':memory:')
+        curs = cls.conn.cursor()
+        curs.execute('CREATE TABLE test (x int)')
+        curs.executemany('INSERT INTO test VALUES (?)', [(i, ) for i in range(16)])
+
+
+class TestBeanquery(APITests, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.table = '#test'
+        cls.conn = beanquery.Connection()
+        cls.conn.tables['test'] = tables.TestTable(0, 16)

--- a/beanquery/numberify_test.py
+++ b/beanquery/numberify_test.py
@@ -11,7 +11,9 @@ from beancount.core import amount
 from beancount.core import position
 from beancount.core import inventory
 from beancount.core import display_context
+
 from beanquery import numberify
+from beanquery.cursor import Column
 
 
 class TestNumerifySimple(unittest.TestCase):
@@ -25,9 +27,9 @@ class TestNumerifySimple(unittest.TestCase):
                      "110 JPY",
                      "-947.00 USD"]
 
-    expected_types = [('pos (CAD)', Decimal),
+    expected_types = (('pos (CAD)', Decimal),
                       ('pos (USD)', Decimal),
-                      ('pos (JPY)', Decimal)]
+                      ('pos (JPY)', Decimal))
 
     expected_rows = [[D('24.17'), None, None],
                      [D('-77.02'), None, None],
@@ -39,21 +41,21 @@ class TestNumerifySimple(unittest.TestCase):
                      [None, D('-947.00'), None]]
 
     def test_amount(self):
-        itypes = [('pos', amount.Amount)]
+        itypes = (Column('pos', amount.Amount), )
         irows = [(A(string),) for string in self.input_amounts]
         atypes, arows = numberify.numberify_results(itypes, irows)
         self.assertEqual(self.expected_types, atypes)
         self.assertEqual(self.expected_rows, arows)
 
     def test_position(self):
-        itypes = [('pos', position.Position)]
+        itypes = (Column('pos', position.Position), )
         irows = [(position.from_string(string),) for string in self.input_amounts]
         atypes, arows = numberify.numberify_results(itypes, irows)
         self.assertEqual(self.expected_types, atypes)
         self.assertEqual(self.expected_rows, arows)
 
     def test_inventory(self):
-        itypes = [('pos', inventory.Inventory)]
+        itypes = (Column('pos', inventory.Inventory), )
         irows = [(inventory.from_string(string),) for string in self.input_amounts]
         atypes, arows = numberify.numberify_results(itypes, irows)
         self.assertEqual(self.expected_types, atypes)
@@ -63,7 +65,7 @@ class TestNumerifySimple(unittest.TestCase):
 class TestNumerifyIdentity(unittest.TestCase):
 
     def test_identity(self):
-        itypes = [('date', datetime.date), ('name', str), ('count', int)]
+        itypes = (Column('date', datetime.date), Column('name', str), Column('count', int), )
         irows = [[datetime.date(2015, 9, 8), 'Testing', 3]]
         atypes, arows = numberify.numberify_results(itypes, irows)
         self.assertEqual(itypes, atypes)
@@ -73,15 +75,15 @@ class TestNumerifyIdentity(unittest.TestCase):
 class TestNumerifyInventory(unittest.TestCase):
 
     def test_inventory(self):
-        itypes = [('balance', inventory.Inventory)]
+        itypes = (Column('balance', inventory.Inventory), )
         irows = [[inventory.from_string('10 HOOL {23.00 USD}')],
                  [inventory.from_string('2.11 USD, 3.44 CAD')],
                  [inventory.from_string('-2 HOOL {24.00 USD}, 5.66 CAD')]]
         atypes, arows = numberify.numberify_results(itypes, irows)
 
-        self.assertEqual([('balance (HOOL)', Decimal),
+        self.assertEqual((('balance (HOOL)', Decimal),
                           ('balance (CAD)', Decimal),
-                          ('balance (USD)', Decimal)], atypes)
+                          ('balance (USD)', Decimal), ), atypes)
 
         self.assertEqual([[D('10'), None, None],
                           [None, D('3.44'), D('2.11')],
@@ -99,10 +101,10 @@ class TestNumerifyPrecision(unittest.TestCase):
         dformat = dcontext.build()
 
         # Input data.
-        itypes = [('number', Decimal),
-                  ('amount', amount.Amount),
-                  ('position', position.Position),
-                  ('inventory', inventory.Inventory)]
+        itypes = (Column('number', Decimal),
+                  Column('amount', amount.Amount),
+                  Column('position', position.Position),
+                  Column('inventory', inventory.Inventory))
         irows = [[D(amt.split()[0]),
                   A(amt),
                   position.from_string(amt),

--- a/beanquery/query.py
+++ b/beanquery/query.py
@@ -33,7 +33,9 @@ def run_query(entries, options_map, query, *format_args, numberify=False):
     formatted_query = query.format(*format_args)
 
     # Execute it to obtain the result rows.
-    rtypes, rrows = ctx.execute(formatted_query)
+    curs = ctx.execute(formatted_query)
+    rrows = curs.fetchall()
+    rtypes = curs.description
 
     # Numberify the results, if requested.
     if numberify:

--- a/beanquery/query_render.py
+++ b/beanquery/query_render.py
@@ -443,8 +443,8 @@ def render_text(columns, rows, dcontext, file, expand=False, boxed=False,
 
     """
     ctx = RenderContext(dcontext, expand=expand, spaced=spaced, listsep=listsep, null=nullvalue)
-    renderers = [RENDERERS[dtype](ctx) for name, dtype in columns]
-    headers = [name for name, dtype in columns]
+    renderers = [RENDERERS[c.datatype](ctx) for c in columns]
+    headers = [c.name for c in columns]
     alignment = [renderer.align for renderer in renderers]
 
     # Prime the renderers.

--- a/beanquery/query_render_test.py
+++ b/beanquery/query_render_test.py
@@ -15,6 +15,7 @@ from beancount.core.number import D
 from beancount.core.position import Position, from_string as P
 
 from beanquery import query_render
+from beanquery.cursor import Column
 
 
 class TestColumnRenderer(unittest.TestCase):
@@ -40,7 +41,7 @@ class RendererTestBase(unittest.TestCase):
     def render(self, dtype, values, **kwargs):
         out = io.StringIO()
         rows = [(x, ) for x in values]
-        query_render.render_text([('', dtype)], rows, self.dcontext, out, **kwargs)
+        query_render.render_text([Column('', dtype)], rows, self.dcontext, out, **kwargs)
         return out.getvalue().splitlines()[2:]
 
 
@@ -332,6 +333,7 @@ class TestQueryRenderText(unittest.TestCase):
         self.dcontext = display_context.DisplayContext()
 
     def render(self, types, rows, **kwargs):
+        types = [Column(*t) for t in types]
         oss = io.StringIO()
         query_render.render_text(types, rows, self.dcontext, oss, **kwargs)
         return oss.getvalue()

--- a/beanquery/query_test.py
+++ b/beanquery/query_test.py
@@ -51,7 +51,7 @@ class TestSimple(unittest.TestCase):
         """
 
         rtypes, rrows = query.run_query(entries, options, sql_query, 'Expenses', numberify=True)
-        columns = [rt[0] for rt in rtypes]
+        columns = [c.name for c in rtypes]
         self.assertEqual(columns, ['account', 'amount (USD)', 'amount (VACHR)', 'amount (IRAUSD)'])
         self.assertEqual(len(rrows[0]), 4)
 

--- a/beanquery/shell.py
+++ b/beanquery/shell.py
@@ -512,7 +512,9 @@ class BQLShell(DispatchingShell):
           CLEAR: Transfer final Income and Expenses balances to Equity.
 
         """
-        rtypes, rrows = self.context.execute(statement)
+        cursor = self.context.execute(statement)
+        rtypes = cursor.description
+        rrows = cursor.fetchall()
 
         if not rrows:
             print("(empty)", file=self.outfile)

--- a/beanquery/sources/beancount.py
+++ b/beanquery/sources/beancount.py
@@ -10,7 +10,7 @@ def add_beancount_tables(context, entries, errors, options):
     context.errors.extend(errors)
 
 
-def attach(context, uri):
-    filename = urlparse(uri).path
+def attach(context, dsn):
+    filename = urlparse(dsn).path
     entries, errors, options = loader.load_file(filename)
     add_beancount_tables(context, entries, errors, options)

--- a/beanquery/tests/tables.py
+++ b/beanquery/tests/tables.py
@@ -1,0 +1,21 @@
+from .. import query_compile
+from .. import tables
+
+
+class TestColumn(query_compile.EvalColumn):
+    def __init__(self, func, datatype):
+        super().__init__(datatype)
+        self.func = func
+
+    def __call__(self, row):
+        return self.func(row)
+
+
+class TestTable(tables.Table):
+    columns = {'x': TestColumn(lambda row: row, int)}
+
+    def __init__(self, *args):
+        self.rows = range(*args)
+
+    def __iter__(self):
+        return iter(self.rows)

--- a/beanquery/types.py
+++ b/beanquery/types.py
@@ -59,3 +59,7 @@ MAP = {
     int: 'int',
     str: 'str',
 }
+
+
+def name(datatype):
+    return getattr(datatype, 'name', datatype.__name__)


### PR DESCRIPTION
Implement relevant aspects of the DB-API 2.0 specification.

https://peps.python.org/pep-0249/

The PEP does not provide a strict specification for some aspects of the API. The under-specified aspects are modeled after the sqlite3 and psycopg implementations.