### PR TITLE
beancount: Define more structured types

### DIFF
--- a/beanquery/query_compile.py
+++ b/beanquery/query_compile.py
@@ -538,8 +538,9 @@ def compile_expression(expr, environ):
 
     if isinstance(expr, ast.Attribute):
         operand = compile_expression(expr.operand, environ)
-        if issubclass(operand.dtype, types.Structure):
-            getter = operand.dtype.columns.get(expr.name)
+        dtype = types.ALIASES.get(operand.dtype, operand.dtype)
+        if issubclass(dtype, types.Structure):
+            getter = dtype.columns.get(expr.name)
             if getter is None:
                 raise CompilationError(f'structured type has no attribute "{expr.name}"', expr)
             return EvalGetter(operand, getter, getter.dtype)

--- a/beanquery/query_env.py
+++ b/beanquery/query_env.py
@@ -757,9 +757,6 @@ class Row:
 
 
 class BeanTable(tables.Table):
-    name = None
-    columns = {}
-
     def __init__(self, entries, options, open=None, close=None, clear=None):
         super().__init__()
         self.entries = entries
@@ -1105,7 +1102,11 @@ def meta(context):
     return context.posting.meta
 
 
-@column(EntriesTable)
+class Entry(EntriesTable, types.Structure):
+    name = 'entry'
+
+
+@column(Entry)
 def entry(context):
     return context
 

--- a/beanquery/query_render.py
+++ b/beanquery/query_render.py
@@ -250,6 +250,36 @@ class AmountRenderer(ColumnRenderer):
         return f'{self.func(value.number, value.currency)} {value.currency:<{self.curwidth}}'
 
 
+class CostRenderer(ObjectRenderer):
+    dtype = position.Cost
+
+    def __init__(self, ctx):
+        super().__init__(ctx)
+        self.amount_renderer = AmountRenderer(ctx)
+        self.date_width = 0
+        self.label_width = 0
+
+    def update(self, value):
+        self.amount_renderer.update(value)
+        if value.date is not None:
+            self.date_width = 10 + 2
+        if value.label is not None:
+            self.label_width = max(self.label_width, len(value.label) + 4)
+
+    def prepare(self):
+        cost_width = self.amount_renderer.prepare()
+        self.maxwidth = cost_width + self.date_width + self.label_width
+        return super().prepare()
+
+    def format(self, value):
+        parts = [self.amount_renderer.format(value)]
+        if value.date is not None:
+            parts.append(f'{value.date:%Y-%m-%d}')
+        if value.label is not None:
+            parts.append(f'"{value.label}"')
+        return ', '.join(parts)
+
+
 class PositionRenderer(ColumnRenderer):
     """Renderer for Position instrnaces.
 

--- a/beanquery/query_render_test.py
+++ b/beanquery/query_render_test.py
@@ -12,7 +12,7 @@ from beancount.core import display_context
 from beancount.core.amount import Amount, A
 from beancount.core.inventory import Inventory, from_string as I
 from beancount.core.number import D
-from beancount.core.position import Position, from_string as P
+from beancount.core.position import Cost, Position, from_string as P
 
 from beanquery import query_render
 from beanquery.cursor import Column
@@ -324,6 +324,22 @@ class TestInventoryRenderer(RendererTestBase):
                                       I('5 AA, 6 EE, 7 FF')], expand=False, listsep=' & '), [
             '10 AA & 2 BB & 3 CC & 4 DD              ',
             ' 5 AA & 6 EE & 7 FF                     ',
+        ])
+
+
+class TestCostRenderer(RendererTestBase):
+
+    def render(self, values, **kwargs):
+        return super().render(Cost, values, **kwargs)
+
+    def test_cost(self):
+        self.dcontext.update(Decimal('1.0000'), 'ETH')
+        self.assertEqual(self.render([Cost(D('1.0'), 'ETH', None, None),
+                                      Cost(D('1.0'), 'ETH', datetime.date(2023, 8, 14), None),
+                                      Cost(D('1.0'), 'ETH', datetime.date(2023, 8, 14), 'label')]), [
+            '1.0000 ETH                     ',
+            '1.0000 ETH, 2023-08-14         ',
+            '1.0000 ETH, 2023-08-14, "label"',
         ])
 
 

--- a/beanquery/sources/beancount.py
+++ b/beanquery/sources/beancount.py
@@ -1,6 +1,15 @@
+import typing
+
 from urllib.parse import urlparse
+
 from beancount import loader
+from beancount.core import data
+from beancount.core import position
+
+from beanquery import types
+from beanquery import query_compile
 from beanquery import query_env
+from beanquery import query_render
 
 
 def add_beancount_tables(context, entries, errors, options):
@@ -14,3 +23,63 @@ def attach(context, dsn):
     filename = urlparse(dsn).path
     entries, errors, options = loader.load_file(filename)
     add_beancount_tables(context, entries, errors, options)
+
+
+class Metadata(dict):
+    pass
+
+
+class MetadataRenderer(query_render.ObjectRenderer):
+    dtype = Metadata
+
+    def format(self, value):
+        return str({k: v for k, v in value.items() if k not in {'filename', 'lineno'}})
+
+
+class GetAttrColumn(query_compile.EvalColumn):
+    def __init__(self, name, dtype):
+        super().__init__(dtype)
+        self.name = name
+
+    def __call__(self, context):
+        return getattr(context, self.name)
+
+
+def _typed_namedtuple_to_columns(cls):
+    columns = {}
+    for name, dtype in typing.get_type_hints(cls).items():
+        origin = typing.get_origin(dtype)
+        # Extract the underlying type from Optional[x] annotations,
+        # which are effectively Union[x, None] annotations.
+        if origin is typing.Union:
+            args = typing.get_args(dtype)
+            # Ensure that there is just one type other than None.
+            dtypes = [t for t in args if t is not type(None)]
+            assert len(dtypes) == 1
+            dtype = dtypes[0]
+        elif origin is not None:
+            dtype = origin
+        if name == 'meta' and dtype is dict:
+            dtype = Metadata
+        columns[name] = GetAttrColumn(name, dtype)
+    return columns
+
+
+class Position(types.Structure):
+    name = 'position'
+    columns = _typed_namedtuple_to_columns(position.Position)
+
+
+class Cost(types.Structure):
+    name = 'cost'
+    columns = _typed_namedtuple_to_columns(data.Cost)
+
+
+class Amount(types.Structure):
+    name = 'amount'
+    columns = _typed_namedtuple_to_columns(data.Amount)
+
+
+types.ALIASES[position.Position] = Position
+types.ALIASES[data.Cost] = Cost
+types.ALIASES[data.Amount] = Amount

--- a/beanquery/tables.py
+++ b/beanquery/tables.py
@@ -1,7 +1,4 @@
-from . import types
-
-
-class Table(types.Structure):
+class Table:
     columns = {}
     name = None
 

--- a/beanquery/types.py
+++ b/beanquery/types.py
@@ -28,9 +28,18 @@ class AsteriskType:
 Asterisk = AsteriskType()
 
 
+# Keep track of the defined structured types to allow introspection.
+TYPES = {}
+
+
 class Structure:
     """Base class for structured data types."""
-    pass
+    name = None
+    columns = {}
+
+    def __init_subclass__(cls):
+        if cls.name:
+            TYPES[cls.name] = cls
 
 
 def function_lookup(functions, name, operands):
@@ -59,6 +68,12 @@ MAP = {
     int: 'int',
     str: 'str',
 }
+
+
+# Map between Python types and BQL structured types. Functions and
+# columns definitions can use Python types. The corresponding BQL
+# structured type is looked up when compiling the subscrip operator.
+ALIASES = {}
 
 
 def name(datatype):


### PR DESCRIPTION
These will eventually replace the functions now used to access the fields of the beancount objects.