### PR TITLE
parser, compiler, cursor: Implement handling of query parameters

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,4 +20,4 @@ jobs:
       - run: pip install 'git+https://github.com/beancount/beancount#egg=beancount'
         if: ${{ matrix.beancount == '3.0' }}
       - run: pip install -r requirements.txt
-      - run: python -m unittest discover -p '*_test.py' -s beanquery/
+      - run: python -m unittest discover -p '*_test.py'

--- a/beanquery/__init__.py
+++ b/beanquery/__init__.py
@@ -5,10 +5,12 @@ from urllib.parse import urlparse
 from . import parser
 from . import compiler
 from . import tables
-from . import cursor
 
-from .parser import ParseError  # noqa: F401
-from .compiler import CompilationError  # noqa: F401
+from .compiler import CompilationError
+from .cursor import Cursor, Column
+from .errors import Warning, Error, InterfaceError, DatabaseError, DataError, OperationalError
+from .errors import IntegrityError, InternalError, ProgrammingError, NotSupportedError
+from .parser import ParseError
 
 
 __version__ = '0.1.dev0'
@@ -45,4 +47,24 @@ class Connection:
         return self.cursor().execute(query, params)
 
     def cursor(self):
-        return cursor.Cursor(self)
+        return Cursor(self)
+
+
+__all__ = [
+    'Column',
+    'CompilationError',
+    'Connection',
+    'Cursor',
+    'DataError',
+    'DatabaseError',
+    'Error',
+    'IntegrityError',
+    'InterfaceError',
+    'InternalError',
+    'NotSupportedError',
+    'OperationalError',
+    'ParseError',
+    'ProgrammingError',
+    'Warning',
+    'connet',
+]

--- a/beanquery/compiler.py
+++ b/beanquery/compiler.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from . import types
 from . import parser
+from .errors import ProgrammingError
 from .parser import ast
 
 from .query_compile import (
@@ -32,9 +33,7 @@ from .query_compile import (
 SUPPORT_IMPLICIT_GROUPBY = True
 
 
-class CompilationError(Exception):
-    """A compiler/interpreter error."""
-
+class CompilationError(ProgrammingError):
     def __init__(self, message, ast=None):
         super().__init__(message)
         self.parseinfo = ast.parseinfo if ast is not None else None

--- a/beanquery/cursor.py
+++ b/beanquery/cursor.py
@@ -89,7 +89,7 @@ class Cursor:
     def execute(self, query, params=None):
         if not isinstance(query, parser.ast.Node):
             query = parser.parse(query)
-        query = compiler.compile(self._context, query)
+        query = compiler.compile(self._context, query, params)
         description, rows = query_execute.execute_query(query)
         self._description = description
         self._rows = rows
@@ -97,6 +97,7 @@ class Cursor:
         return self
 
     def executemany(self, query, params=None):
+        query = parser.parse(query)
         for p in params:
             self.execute(query, p)
 

--- a/beanquery/errors.py
+++ b/beanquery/errors.py
@@ -1,0 +1,75 @@
+"""
+Exceptions hierarchy defined by the DB-API:
+
+    Exception
+      Warning
+      Error
+        InterfaceError
+        DatabaseError
+          DataError
+          OperationalError
+          IntegrityError
+          InternalError
+          ProgrammingError
+          NotSupportedError
+"""
+
+
+class Warning(Exception):
+    """Exception raised for important warnings."""
+
+    __module__ = 'beanquery'
+
+
+class Error(Exception):
+    """Base exception for all errors."""
+
+    __module__ = 'beanquery'
+
+
+class InterfaceError(Error):
+    """An error related to the database interface rather than the database itself."""
+
+    __module__ = 'beanquery'
+
+
+class DatabaseError(Error):
+    """Exception raised for errors that are related to the database."""
+
+    __module__ = 'beanquery'
+
+
+class DataError(DatabaseError):
+    """An error caused by problems with the processed data."""
+
+    __module__ = 'beanquery'
+
+
+class OperationalError(DatabaseError):
+    """An error related to the database's operation."""
+
+    __module__ = 'beanquery'
+
+
+class IntegrityError(DatabaseError):
+    """An error caused when the relational integrity of the database is affected."""
+
+    __module__ = 'beanquery'
+
+
+class InternalError(DatabaseError):
+    """An error generated when the database encounters an internal error."""
+
+    __module__ = 'beanquery'
+
+
+class ProgrammingError(DatabaseError):
+    """Exception raised for programming errors."""
+
+    __module__ = 'beanquery'
+
+
+class NotSupportedError(DatabaseError):
+    """A method or database API was used which is not supported by the database."""
+
+    __module__ = 'beanquery'

--- a/beanquery/parser/__init__.py
+++ b/beanquery/parser/__init__.py
@@ -48,7 +48,7 @@ class BQLSemantics:
 
     def from_(self, value, typename):
         if value['expression'] is None and value['open'] is None and value['close'] is None and value['clear_'] is None:
-            self._ctx._error('Empty FROM expression is not allowed')
+            self._ctx._error('empty FROM expression is not allowed')
         return self._default(value, typename)
 
     def _default(self, value, typename=None):

--- a/beanquery/parser/__init__.py
+++ b/beanquery/parser/__init__.py
@@ -58,5 +58,5 @@ class BQLSemantics:
         return value
 
 
-def parse(text, default_close_date=None):
+def parse(text):
     return parser.BQLParser().parse(text, semantics=BQLSemantics())

--- a/beanquery/parser/ast.py
+++ b/beanquery/parser/ast.py
@@ -26,6 +26,16 @@ def tosexp(node):
     return repr(node)
 
 
+def walk(node):
+    if isinstance(node, Node):
+        for name, child in _fields(node):
+            yield from walk(child)
+        yield node
+    if isinstance(node, list):
+        for child in node:
+            yield from walk(child)
+
+
 class Node:
     """Base class for BQL AST nodes."""
     __slots__ = ()
@@ -40,6 +50,9 @@ class Node:
 
     def tosexp(self):
         return tosexp(self)
+
+    def walk(self):
+        return walk(self)
 
 
 def node(name, fields):
@@ -176,6 +189,12 @@ Subscript = node('Subscript', 'operand key')
 # Attributes:
 #   value: The constant value this represents.
 Constant = node('Constant', 'value')
+
+# A query parameter placeholder.
+#
+# Attributes:
+#   name: The placeholder name
+Placeholder = node('Placeholder', 'name')
 
 # Base class for unary operators.
 #

--- a/beanquery/parser/bql.ebnf
+++ b/beanquery/parser/bql.ebnf
@@ -248,6 +248,13 @@ atom
     | function
     | constant
     | column
+    | placeholder
+    ;
+
+placeholder::Placeholder
+    =
+    | '%s' name:``
+    | '%(' name:identifier ')s'
     ;
 
 function::Function

--- a/beanquery/parser/parser.py
+++ b/beanquery/parser/parser.py
@@ -930,8 +930,8 @@ class BQLParser(Parser):
             self._error(
                 'expecting one of: '
                 "'SELECT' <atom> <attribute> <column>"
-                '<constant> <function> <primary> <select>'
-                '<subscript>'
+                '<constant> <function> <placeholder>'
+                '<primary> <select> <subscript>'
             )
 
     @tatsumasu('Attribute')
@@ -974,12 +974,41 @@ class BQLParser(Parser):
                 self._constant_()
             with self._option():
                 self._column_()
+            with self._option():
+                self._placeholder_()
             self._error(
                 'expecting one of: '
-                "'SELECT' <boolean> <column> <constant>"
-                '<date> <decimal> <function> <identifier>'
-                '<integer> <list> <literal> <null>'
-                '<select> <string>'
+                "'%(' '%s' 'SELECT' <boolean> <column>"
+                '<constant> <date> <decimal> <function>'
+                '<identifier> <integer> <list> <literal>'
+                '<null> <placeholder> <select> <string>'
+            )
+
+    @tatsumasu('Placeholder')
+    def _placeholder_(self):  # noqa
+        with self._choice():
+            with self._option():
+                self._token('%s')
+                self._constant('')
+                self.name_last_node('name')
+
+                self._define(
+                    ['name'],
+                    []
+                )
+            with self._option():
+                self._token('%(')
+                self._identifier_()
+                self.name_last_node('name')
+                self._token(')s')
+
+                self._define(
+                    ['name'],
+                    []
+                )
+            self._error(
+                'expecting one of: '
+                "'%(' '%s'"
             )
 
     @tatsumasu('Function')
@@ -1360,6 +1389,9 @@ class BQLSemantics:
         return ast
 
     def atom(self, ast):  # noqa
+        return ast
+
+    def placeholder(self, ast):  # noqa
         return ast
 
     def function(self, ast):  # noqa

--- a/beanquery/parser_test.py
+++ b/beanquery/parser_test.py
@@ -624,6 +624,11 @@ class TestRepr(unittest.TestCase):
                     name: 'b')
                   ordering: desc)))'''))
 
+    def test_walk(self):
+        query = parser.parse('SELECT a + 1 FROM #test WHERE a > %(foo)s ORDER BY b DESC')
+        placeholders = [node for node in query.walk() if isinstance(node, ast.Placeholder)]
+        self.assertEqual(placeholders, [ast.Placeholder(name='foo')])
+
 
 class TestNodeText(unittest.TestCase):
 

--- a/beanquery/shell.py
+++ b/beanquery/shell.py
@@ -64,20 +64,13 @@ def render_location(text, pos, endpos, lineno, indent, strip, out):
 # information uniformly. This requires translating TatSu exceptions
 # into something else.
 def render_exception(exc, indent='| ', strip=True):
-    if isinstance(exc, beanquery.CompilationError) and exc.parseinfo:
+    if isinstance(exc, (beanquery.CompilationError, beanquery.ParseError)) and exc.parseinfo:
         out = []
         pos = exc.parseinfo.pos
         endpos = exc.parseinfo.endpos
         lineno = exc.parseinfo.line
         render_location(exc.parseinfo.tokenizer.text, pos, endpos, lineno, indent, strip, out)
         out.append(f'error: {exc}')
-        return '\n'.join(out)
-
-    if isinstance(exc, beanquery.ParseError):
-        out = []
-        info = exc.tokenizer.line_info(exc.pos)
-        render_location(exc.tokenizer.text, exc.pos, exc.pos + 1, info.line, indent, strip, out)
-        out.append('error: syntax error')
         return '\n'.join(out)
 
     return 'error:\n' + traceback.format_exc()


### PR DESCRIPTION
Further steps toward DB-API 2.0 compliance. Allow binding query parameters to "%s" positional or "%(name)s" named placeholders.

The parameters are injected as constants nodes into the query execution tree at compile time, thus no escaping (or even the definition of a string representation) for parameters is required.