### PR TITLE
Use dateutil.parser directly

### DIFF
--- a/beanquery/query_env.py
+++ b/beanquery/query_env.py
@@ -16,6 +16,8 @@ import textwrap
 from functools import lru_cache as cache
 from decimal import Decimal
 
+import dateutil.parser
+
 from beancount.core.number import ZERO
 from beancount.core.compare import hash_entry
 from beancount.core import amount
@@ -29,7 +31,6 @@ from beancount.core import convert
 from beancount.core import prices
 from beancount.ops import summarize
 from beancount.parser import options as opts
-from beancount.utils.date_utils import parse_date_liberally
 
 from beanquery import query_compile
 from beanquery import tables
@@ -554,7 +555,7 @@ def possign(context, x, account):
 def parse_date(string, frmt=None):
     """Parse date from string."""
     if frmt is None:
-        return parse_date_liberally(string)
+        return dateutil.parser.parse(string).date()
     return datetime.datetime.strptime(string, frmt).date()
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ packages = find:
 install_requires =
     beancount >=2.3.4
     click >7.0
+    python-dateutil >=2.6.0
     tatsu >=5.7.4, <5.8.0
 python_requires = >=3.8
 


### PR DESCRIPTION
Remove indirection via beancount.utils.date_utils. This makes the dependency on python-dateutil explicit and will allow to remove the utility code from Beancount and thus the Beancount dependency on python-dateutil.

The one argument form of the parse_date() BQL function that tries to guess the date format does not seem a great idea. In the future, it should probably be deprecated and removed.