### PR TITLE
Fix CSV rendering

### DIFF
--- a/beanquery/query_render.py
+++ b/beanquery/query_render.py
@@ -472,7 +472,7 @@ def render_text(columns, rows, dcontext, file, expand=False, boxed=False,
     """Render the result of executing a query in text format.
 
     Args:
-      columns: A list of (name, dtype) tuples descrining the table columns.
+      columns: A list of beanquery.Column descrining the table columns.
       rows: Data to render.
       dcontext: A DisplayContext object prepared for rendering numbers.
       file: A file object to render the results to.
@@ -487,7 +487,7 @@ def render_text(columns, rows, dcontext, file, expand=False, boxed=False,
     """
     ctx = RenderContext(dcontext, expand=expand, spaced=spaced, listsep=listsep, null=nullvalue)
     renderers = [_get_renderer(column.datatype, ctx) for column in columns]
-    headers = [c.name for c in columns]
+    headers = [column.name for column in columns]
     alignment = [renderer.align for renderer in renderers]
 
     # Prime the renderers.
@@ -537,7 +537,7 @@ def render_csv(columns, rows, dcontext, file, expand=False, nullvalue='', **kwar
     """Render the result of executing a query in text format.
 
     Args:
-      columns: A list of (name, dtype) tuples descrining the table columns.
+      columns: A list of beanquery.Column describing the table columns.
       rows: Data to render.
       dcontext: A DisplayContext object prepared for rendering numbers.
       file: A file object to render the results to.
@@ -545,8 +545,8 @@ def render_csv(columns, rows, dcontext, file, expand=False, nullvalue='', **kwar
       nullvalue: String to use to represent NULL values.
     """
     ctx = RenderContext(dcontext, expand=expand, spaced=False, listsep=',', null=nullvalue)
-    renderers = [RENDERERS[dtype](ctx) for name, dtype in columns]
-    headers = [name for name, dtype in columns]
+    renderers = [_get_renderer(column.datatype, ctx) for column in columns]
+    headers = [column.name for column in columns]
 
     # Prime the renderers.
     for row in rows:

--- a/beanquery/query_render_test.py
+++ b/beanquery/query_render_test.py
@@ -508,7 +508,7 @@ class TestQueryRenderCSV(unittest.TestCase):
 
     def test_render_simple(self):
         self.assertEqual(self.render(
-            [('x', int), ('y', int), ('z', int)],
+            [Column('x', int), Column('y', int), Column('z', int)],
             [(1, 2, 3), (4, 5, 6)]), textwrap.dedent(
                 """\
                 x,y,z
@@ -518,7 +518,7 @@ class TestQueryRenderCSV(unittest.TestCase):
 
     def test_render_missing(self):
         self.assertEqual(self.render(
-            [('x', int), ('y', int), ('z', int)],
+            [Column('x', int), Column('y', int), Column('z', int)],
             [(None, 2, 3), (4, None, 6)]), textwrap.dedent(
                 """\
                 x,y,z
@@ -528,7 +528,7 @@ class TestQueryRenderCSV(unittest.TestCase):
 
     def test_render_expand(self):
         self.assertEqual(self.render(
-            [('x', int), ('inv', Inventory), ('q', int)],
+            [Column('x', int), Column('inv', Inventory), Column('q', int)],
             [(11, I('1.00 USD, 1.00 EUR, 1 TESTS'), 2),
              (33, I('2.00 EUR, 42 TESTS'), 4)], expand=True), "\n".join([
                  "x,inv,q",


### PR DESCRIPTION
Fixes:

      File ".../beanquery/query_render.py", line 548, in <listcomp>
        renderers = [RENDERERS[dtype](ctx) for name, dtype in columns]
                                               ^^^^^^^^^^^
    ValueError: too many values to unpack (expected 2)

columns is no longer a tuple but a list of `beanquery.Column` objects. Fix accessors to datatype and name.