### PR TITLE
render: Make results set rendering formats extensible

### DIFF
--- a/beanquery/render/csv.py
+++ b/beanquery/render/csv.py
@@ -1,0 +1,5 @@
+from ..query_render import render_csv
+
+
+def render(desc, rows, file, *, dcontext, **kwargs):
+    return render_csv(desc, rows, file, dcontext, **kwargs)

--- a/beanquery/render/text.py
+++ b/beanquery/render/text.py
@@ -1,0 +1,7 @@
+from ..query_render import render_text
+
+
+def render(desc, rows, file, *, dcontext, **kwargs):
+    if not rows:
+        return print("(empty)", file=file)
+    return render_text(desc, rows, dcontext, file, **kwargs)

--- a/beanquery/shell.py
+++ b/beanquery/shell.py
@@ -554,21 +554,21 @@ class BQLShell(DispatchingShell):
 
         """
         cursor = self.context.execute(statement)
-        rtypes = cursor.description
-        rrows = cursor.fetchall()
+        desc = cursor.description
+        rows = cursor.fetchall()
+        dcontext = self.context.options['dcontext']
 
-        if not rrows:
-            print("(empty)", file=self.outfile)
-        elif self.settings.format == Format.TEXT:
-            with self.output as out:
-                render_text(rtypes, rrows, self.context.options['dcontext'], out, **self.settings.todict())
-        elif self.settings.format == Format.CSV:
-            if self.settings.numberify:
-                dformat = self.context.options['dcontext'].build()
-                rtypes, rrows = numberify_results(rtypes, rrows, dformat)
-            render_csv(rtypes, rrows, self.context.options['dcontext'], self.outfile, **self.settings.todict())
-        else:
-            raise NotImplementedError
+        if not rows:
+            return print("(empty)", file=self.outfile)
+
+        if self.settings.numberify:
+            desc, rows = numberify_results(desc, rows, dcontext.build())
+
+        with self.output as out:
+            if self.settings.format == Format.TEXT:
+                render_text(desc, rows, dcontext, out, **self.settings.todict())
+            elif self.settings.format == Format.CSV:
+                render_csv(desc, rows, dcontext, out, **self.settings.todict())
 
     def on_Journal(self, journal):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ exclude_also = [
 ]
 
 [tool.ruff]
+line-length = 128
+target-version = 'py38'
+
+[tool.ruff.lint]
 select = ['E', 'F', 'W', 'UP', 'B', 'C4', 'PL', 'RUF']
 ignore = [
     'B007',
@@ -76,8 +80,6 @@ ignore = [
 exclude = [
     'beanquery/parser/parser.py'
 ]
-line-length = 128
-target-version = 'py38'
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 'beanquery/query_env.py' = ['F811']


### PR DESCRIPTION
The supported rendering formats can be extended adding modules exposing a `render()` function in the `beanquery.render` namespace. See the `beanquery.render.text` and `beanquery.render.csv` modules as examples.