### PR TITLE
add date_trunc and interval functions

### DIFF
--- a/beanquery/query_compile.py
+++ b/beanquery/query_compile.py
@@ -15,6 +15,8 @@ import operator
 from decimal import Decimal
 from itertools import product
 
+from dateutil.relativedelta import relativedelta
+
 from beanquery.parser import ast
 from beanquery import query_execute
 from beanquery import types
@@ -245,6 +247,9 @@ def mod_(x, y):
 @binaryop(ast.Add, [Decimal, int], Decimal)
 @binaryop(ast.Add, [int, Decimal], Decimal)
 @binaryop(ast.Add, [int, int], int)
+@binaryop(ast.Add, [datetime.date, relativedelta], datetime.date)
+@binaryop(ast.Add, [relativedelta, datetime.date], datetime.date)
+@binaryop(ast.Add, [relativedelta, relativedelta], relativedelta)
 def add_(x, y):
     return x + y
 
@@ -253,6 +258,9 @@ def add_(x, y):
 @binaryop(ast.Sub, [Decimal, int], Decimal)
 @binaryop(ast.Sub, [int, Decimal], Decimal)
 @binaryop(ast.Sub, [int, int], int)
+@binaryop(ast.Sub, [datetime.date, relativedelta], datetime.date)
+@binaryop(ast.Sub, [relativedelta, datetime.date], datetime.date)
+@binaryop(ast.Sub, [relativedelta, relativedelta], datetime.date)
 def sub_(x, y):
     return x - y
 


### PR DESCRIPTION
Add `last_day()` function to retrieve the last day of a given month.
Useful for generating monthly reports, when showing e.g. the market value at the end of each month:

```
SELECT year, month,
CONVERT(LAST(balance), 'USD', LAST_DAY(FIRST(year))) AS market_value,
WHERE account ~ '^Assets:'
GROUP BY year, month 
```