### PR TITLE
Add "beancount" result set renderer

### DIFF
--- a/beanquery/compiler.py
+++ b/beanquery/compiler.py
@@ -25,6 +25,7 @@ from .query_compile import (
     EvalPrint,
     EvalQuery,
     EvalConstantSubquery1D,
+    EvalRow,
     EvalTarget,
     FUNCTIONS,
     OPERATORS,
@@ -525,6 +526,10 @@ class Compiler:
     @_compile.register
     def _function(self, node: ast.Function):
         operands = [self._compile(operand) for operand in node.operands]
+
+        # ``row(*)`` is parsed like a function call but does something special
+        if node.fname == 'row' and len(operands) == 1 and operands[0].dtype == types.Asterisk:
+            return EvalRow()
 
         # ``coalesce()`` is parsed like a function call but it does
         # not really fit our model for function evaluation, therefore

--- a/beanquery/compiler.py
+++ b/beanquery/compiler.py
@@ -22,7 +22,6 @@ from .query_compile import (
     EvalGetter,
     EvalOr,
     EvalPivot,
-    EvalPrint,
     EvalQuery,
     EvalConstantSubquery1D,
     EvalRow,
@@ -708,7 +707,8 @@ class Compiler:
     def _print(self, node: ast.Print):
         self.table = self.context.tables.get('entries')
         expr = self._compile_from(node.from_clause)
-        return EvalPrint(self.table, expr)
+        targets = [EvalTarget(EvalRow(), 'ROW(*)', False)]
+        return EvalQuery(self.table, targets, expr, None, None, None, None, False)
 
 
 def transform_journal(journal):

--- a/beanquery/query_compile.py
+++ b/beanquery/query_compile.py
@@ -643,11 +643,3 @@ class EvalQuery:
 #   query: The underlying EvalQuery.
 #   pivots: The pivot columns indexes
 EvalPivot = collections.namedtuple('EvalPivot', 'query pivots')
-
-
-# A compiled print statement, ready for execution.
-#
-# Attributes:
-#   table: Table to print
-#   where: Filtering expression, EvalNode instance.
-EvalPrint = collections.namedtuple('EvalPrint', 'table where')

--- a/beanquery/query_compile.py
+++ b/beanquery/query_compile.py
@@ -484,6 +484,16 @@ class EvalAll(EvalNode):
         return all(self.op(left, x) for x in right)
 
 
+class EvalRow(EvalNode):
+    __slots__ = ()
+
+    def __init__(self):
+        super().__init__(object)
+
+    def __call__(self, context):
+        return context
+
+
 class EvalColumn(EvalNode):
     pass
 

--- a/beanquery/query_compile_test.py
+++ b/beanquery/query_compile_test.py
@@ -699,16 +699,23 @@ class TestTranslationBalance(CompileSelectBase):
         None, self.group_by, self.order_by, None, None, None))
 
     def test_print(self):
-        self.assertCompile(qc.EvalPrint(Table('entries'), None), "PRINT;")
+        self.assertCompile(
+            qc.EvalQuery(
+                Table('entries'),
+                [qc.EvalTarget(qc.EvalRow(), 'ROW(*)', False)],
+                None, None, None, None, None, False),
+            "PRINT;",
+        )
 
     def test_print_from(self):
         self.assertCompile(
-            qc.EvalPrint(
+            qc.EvalQuery(
                 Table('entries'),
+                [qc.EvalTarget(qc.EvalRow(), 'ROW(*)', False)],
                 qc.Operator(ast.Equal, [
                     Column('year', int),
-                    qc.EvalConstant(2014),
-                ])),
+                    qc.EvalConstant(2014) ]),
+                None, None, None, None, False),
             "PRINT FROM year = 2014;")
 
 

--- a/beanquery/query_execute.py
+++ b/beanquery/query_execute.py
@@ -7,9 +7,6 @@ import collections
 import itertools
 import operator
 
-from beancount.core import display_context
-from beancount.parser import printer
-
 from . import compiler
 from . import query_compile
 from .cursor import Column
@@ -21,28 +18,6 @@ def uniquify(iterable):
         if obj not in seen:
             seen.add(obj)
             yield obj
-
-
-def execute_print(c_print, file):
-    """Print entries from a print statement specification.
-
-    Args:
-      c_print: An instance of a compiled EvalPrint statement.
-      file: The output file to print to.
-    """
-    # Filter the entries with the FROM clause expression.
-    entries = []
-    expr = c_print.where
-    for row in c_print.table:
-        if expr is None or expr(row):
-            entries.append(row)
-
-    # Create a context that renders all numbers with their natural
-    # precision, but honors the commas option. This is kept in sync with
-    # {2c694afe3140} to avoid a dependency.
-    dcontext = display_context.DisplayContext()
-    dcontext.set_commas(c_print.table.options['dcontext'].commas)
-    printer.print_entries(entries, dcontext, file=file)
 
 
 class Allocator:

--- a/beanquery/query_execute_test.py
+++ b/beanquery/query_execute_test.py
@@ -2,7 +2,6 @@ __copyright__ = "Copyright (C) 2014-2017  Martin Blais"
 __license__ = "GNU GPLv2"
 
 import datetime
-import io
 import unittest
 import textwrap
 
@@ -678,26 +677,6 @@ class TestFilterEntries(CommonInputBase, QueryBase):
             Equity:Earnings:Current                            -510.00 USD
 
         """), filtered_entries)
-
-
-class TestExecutePrint(CommonInputBase, QueryBase):
-
-    def test_print_with_filter(self):
-        oss = io.StringIO()
-        qx.execute_print(self.compile("PRINT FROM year = 2012"), oss)
-
-        self.assertEqualEntries("""
-
-          2012-02-02 * "Dinner with Dos"
-            Assets:Bank:Checking                                                   102.00 USD
-            Expenses:Restaurant                                                   -102.00 USD
-
-        """, oss.getvalue())
-
-    def test_print_with_no_filter(self):
-        oss = io.StringIO()
-        qx.execute_print(self.compile("PRINT"), oss)
-        self.assertEqualEntries(self.INPUT, oss.getvalue())
 
 
 class TestAllocation(unittest.TestCase):

--- a/beanquery/render/beancount.py
+++ b/beanquery/render/beancount.py
@@ -1,0 +1,11 @@
+from beancount.core import display_context
+from beancount.parser import printer
+
+
+def render(desc, rows, file, *, dcontext, **kwargs):
+    # Create a display context that renders all numbers with their
+    # natural precision, but honors the commas option in the ledger.
+    commas = dcontext.commas
+    dcontext = display_context.DisplayContext()
+    dcontext.set_commas(commas)
+    return printer.print_entries([entry for entry, in rows], dcontext, file=file)

--- a/beanquery/shell.py
+++ b/beanquery/shell.py
@@ -34,7 +34,6 @@ from beanquery import query_compile
 from beanquery import render
 from beanquery import types
 from beanquery.numberify import numberify_results
-from beanquery.query_execute import execute_print
 
 try:
     import readline
@@ -529,10 +528,12 @@ class BQLShell(DispatchingShell):
             CLEAR operations).
 
         """
-        # Compile the print statement.
-        query = self.context.compile(statement)
-        with self.output as out:
-            execute_print(query, out)
+        frmt = self.settings.format
+        try:
+            self.settings.format = 'beancount'
+            self.on_Select(statement)
+        finally:
+            self.settings.format = frmt
 
     def on_Select(self, statement):
         """


### PR DESCRIPTION
I'm opening this PR mostly to record some thoughts. What it is implemented here is the bare minimum that would be required to make the `PRINT` statement a special case of `SELECT` with `format` set to `beancount`. This works:
```
.set format beancount
SELECT entry FROM #postings WHERE date > 2024-01-01
```
and prints all transactions in the beancount syntax. Actually, all transactions are printed one for every posting they contain. This could be solved with a `DISTINCT` clause, but entries are not hashable, thus
```
SELECT DISTINCT entry FROM #postings WHERE date > 2024-01-01
```
results in an error. This should probably be solved. Entries can be easily make hashable assuming that they are immutable.

However, when selecting for an account, this already does what is expected when filtering for an account:
```
.set format beancount
SELECT entry FROM #posting WHERE date > 2024-01-01 AND account = 'Assets:Foo'
```
and may already be useful to solve what @tbm was asking for in #123.

It is more tricky to make this work for tables that do not have a beancount entry type column. The best I can come up with is to use the `ROW()` [construct](https://www.postgresql.org/docs/current/sql-expressions.html#SQL-SYNTAX-ROW-CONSTRUCTORS). For example:
```
.set format beancount
SELECT ROW(*) FROM #entries WHERE date > 2024-01-01
```
