### PR TITLE
Tiny API tweaks

### DIFF
--- a/beanquery/__init__.py
+++ b/beanquery/__init__.py
@@ -27,11 +27,11 @@ def connect(dsn, **kwargs):
 
 
 class Connection:
-    def __init__(self, dsn=None, **kwargs):
+    def __init__(self, dsn='', **kwargs):
         self.tables = {'': tables.NullTable()}
         self.options = {}
         self.errors = []
-        if dsn is not None:
+        if dsn:
             self.attach(dsn, **kwargs)
 
     def attach(self, dsn, **kwargs):

--- a/beanquery/sources/beancount.py
+++ b/beanquery/sources/beancount.py
@@ -19,7 +19,7 @@ from beanquery import query_render
 TABLES = [query_env.EntriesTable, query_env.PostingsTable]
 
 
-def attach(context, dsn, entries=None, errors=None, options=None):
+def attach(context, dsn, *, entries=None, errors=None, options=None):
     filename = urlparse(dsn).path
     if filename:
         entries, errors, options = loader.load_file(filename)


### PR DESCRIPTION
Use the empty string as default data source name: it makes typing a tiny bit easier and reflects what other DB-ABI implementations use.

Mark additional arguments to the attach() function as keyword only.