### PR TITLE
uses: astral-sh/ruff-action@v3

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -7,11 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - run: python -m pip install ruff
-      - run: ruff check beanquery/
+      - uses: astral-sh/ruff-action@v3
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
+        with:
+          args: "check --output-format=full"
   coverage:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
https://github.com/astral-sh/ruff-action

Ruff is written in Rust so it does not require any particular version of Python.