### PR TITLE
sources.beancount: Correct type for links and tags columns

### DIFF
--- a/beanquery/query_render.py
+++ b/beanquery/query_render.py
@@ -147,6 +147,10 @@ class SetRenderer(ColumnRenderer):
         return self.sep.join(str(x) for x in sorted(value))
 
 
+class FrozensetRenderer(SetRenderer):
+    dtype = frozenset
+
+
 class DateRenderer(ColumnRenderer):
     dtype = datetime.date
 

--- a/beanquery/query_render_test.py
+++ b/beanquery/query_render_test.py
@@ -100,6 +100,13 @@ class TestRenderer(RendererTestBase):
             'bb  ccc',
         ])
 
+    def test_frozenset_str(self):
+        self.assertEqual(self.render(frozenset, [frozenset({}), frozenset({'aaaa'}), frozenset({'bb', 'ccc'})]), [
+            '       ',
+            'aaaa   ',
+            'bb  ccc',
+        ])
+
     def test_date(self):
         self.assertEqual(self.render(datetime.date, [datetime.date(2014, 10, 3)]), [
             '2014-10-03'

--- a/beanquery/sources/beancount.py
+++ b/beanquery/sources/beancount.py
@@ -357,12 +357,12 @@ class EntriesTable(_BeancountTable):
             return None
         return ' | '.join(filter(None, [entry.payee, entry.narration]))
 
-    @columns.register(set)
+    @columns.register(frozenset)
     def tags(entry):
         """The set of tags of the transaction."""
         return getattr(entry, 'tags', None)
 
-    @columns.register(set)
+    @columns.register(frozenset)
     def links(entry):
         """The set of links of the transaction."""
         return getattr(entry, 'links', None)
@@ -493,12 +493,12 @@ class PostingsTable(_BeancountTable):
         """A combination of the payee + narration for the transaction of this posting."""
         return ' | '.join(filter(None, [context.entry.payee, context.entry.narration]))
 
-    @columns.register(set)
+    @columns.register(frozenset)
     def tags(context):
         """The set of tags of the parent transaction for this posting."""
         return context.entry.tags
 
-    @columns.register(set)
+    @columns.register(frozenset)
     def links(context):
         """The set of links of the parent transaction for this posting."""
         return context.entry.links


### PR DESCRIPTION
Currently, `[...] GROUP BY links` throws the following exception:

    beanquery.compiler.CompilationError: GROUP-BY a non-hashable type is not supported: "Column(name='links')"

because `set` is not hashable. `frozenset` is hashable, and can be used for the `links` and `tags` which don't need to be mutable.