### PR TITLE
pyproject.toml: use SPDX identifier to describe license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = 'setuptools.build_meta'
 name = 'beanquery'
 version = '0.3.0.dev0'
 description = 'Customizable lightweight SQL query tool'
-license = { file = 'LICENSE' }
+license = 'GPL-2.0-only'
 readme = 'README.rst'
 authors = [
     { name = 'Martin Blais', email = 'blais@furius.ca' },


### PR DESCRIPTION
Rationale: by specifying the license as a file (like before), the full text of the license is included in the package metadata, and shown in various places, e.g., in the output of `pip show`, which is quite cumbersome. With this change, we use the alternative way of specifying license (namely: using a standard SPDX identifier), which makes license metadata concise and, incidentally, also machine readable.