### PR TITLE
Improve function help by grouping by function type

### DIFF
--- a/beanquery/query_env.py
+++ b/beanquery/query_env.py
@@ -56,7 +56,7 @@ def function(intypes, outtype, pass_context=None, name=None, groups=None):
            or is pure.
       name: Name of the function.
       groups: In which group(s) the function in the help output (list). See 
-           shell._describe_function for group names.
+           shell.TYPE_CATEGORIES for valid group names.
     """
     def decorator(func):
         class Func(query_compile.EvalFunction):
@@ -88,7 +88,7 @@ def register(name=None, groups=None):
     Args:
       name: Name of the function.
       groups: In which group(s) the function in the help output (list). See 
-           shell._describe_function for group names.    
+           shell.TYPE_CATEGORIES for valid group names.    
     """
     def decorator(cls):
         if name is not None:
@@ -800,8 +800,8 @@ def aggregator(intypes, name=None, groups=None):
     Args:
       intypes: A list of types that the aggregator can accept.
       name: The name of the aggregator function.
-      groups: A list of groups that the aggregator belongs to. See the
-           function shell._describe_groups for a list of valid groups.
+      groups: A list of groups that the aggregator belongs to. See 
+           shell.TYPE_CATEGORIES for valid group names.
     """
     def decorator(cls):
         cls.__intypes__ = intypes

--- a/beanquery/query_env.py
+++ b/beanquery/query_env.py
@@ -78,6 +78,8 @@ def register(name=None):
 
 @register('getitem')
 class GetItem2(query_compile.EvalFunction):
+    """Get one item from a dict object if it exists, otherwise None.
+    Arguments: dict, key."""
     __intypes__ = [dict, str]
 
     def __init__(self, context, operands):
@@ -93,6 +95,8 @@ class GetItem2(query_compile.EvalFunction):
 
 @register('getitem')
 class GetItem3(query_compile.EvalFunction):
+    """Get one item from a dict object if it exists, otherwise a default value.
+    Arguments: dict, key, default value."""
     __intypes__ = [dict, str, types.Any]
 
     def __init__(self, context, operands):
@@ -128,6 +132,7 @@ def bool_(x):
 @function([str], int, name='int')
 @function([object], int, name='int')
 def int_(x):
+    """Convert the object to an integer number."""
     try:
         return int(x)
     except (ValueError, TypeError):
@@ -140,6 +145,7 @@ def int_(x):
 @function([str], Decimal, name='decimal')
 @function([object], Decimal, name='decimal')
 def decimal_(x):
+    """Convert the object to a decimal number."""
     try:
         return Decimal(x)
     except (ValueError, TypeError, decimal.InvalidOperation):
@@ -148,6 +154,7 @@ def decimal_(x):
 
 @function([types.Any], str, name='str')
 def str_(x):
+    """Convert any object to a string."""
     if x is True:
         return 'TRUE'
     if x is False:
@@ -159,6 +166,9 @@ def str_(x):
 @function([str], datetime.date, name='date')
 @function([object], datetime.date, name='date')
 def date_(x):
+    """Convert the argument to a date. The argument should be 
+    a string in the format YYYY-MM-DD. Date objects are passed 
+    unchanged. Objects are converted to None."""
     if isinstance(x, datetime.date):
         return x
     if isinstance(x, str):
@@ -316,7 +326,7 @@ def leaf(acc):
 
 @function([str, str], str)
 def grep(pattern, string):
-    """Match a regular expression against a string and return only the matched portion."""
+    """Match a regular expression against a string and return only the matched portion. Arguments: Regex pattern, input string."""
     match = re.search(pattern, string)
     if match:
         return match.group(0)
@@ -325,7 +335,7 @@ def grep(pattern, string):
 
 @function([str, str, int], str)
 def grepn(pattern, string, n):
-    """Match a pattern with subgroups against a string and return the subgroup at the index."""
+    """Match a pattern with subgroups against a string and return the subgroup at the index. Arguments: Regex pattern, input string, subgroup index."""
     match = re.search(pattern, string)
     if match:
         return match.group(n)
@@ -334,7 +344,7 @@ def grepn(pattern, string, n):
 
 @function([str, str, str], str)
 def subst(pattern, repl, string):
-    """Substitute leftmost non-overlapping occurrences of pattern by replacement."""
+    """Substitute leftmost non-overlapping occurrences of pattern by replacement. Arguments: regex pattern, replacement, input string."""
     return re.sub(pattern, repl, string)
 
 
@@ -375,7 +385,9 @@ def close_date(context, acc):
 @function([str], dict, pass_context=True)
 @function([str, str], object, pass_context=True)
 def open_meta(context, account, key=None):
-    """Get the metadata dict of the open directive of the account."""
+    """Get the metadata dict of the open directive of the account. 
+    With one argument, returns all metadata as a dict object. With two
+    arguments, returns the value of a specific metadata key."""
     open_entry, _ = context.tables['accounts'].accounts.get(account, NONENONE)
     if open_entry is None:
         return None
@@ -614,7 +626,11 @@ types.ALIASES[datetime.date] = Date
 @function([str], datetime.date)
 @function([str, str], datetime.date)
 def parse_date(string, frmt=None):
-    """Parse date from string."""
+    """Parse date from string (first argument). Without second argument, 
+    the 'dateutil' library is used to parse the string. This can deal with
+    text like 'February 2nd', 'yesterday', 'next month'. The optional second 
+    argument specifies the format as in the 'datetime' library, for example:
+    '%Y-%m-%d' to parse '2022-01-20'."""
     if frmt is None:
         return dateutil.parser.parse(string).date()
     return datetime.datetime.strptime(string, frmt).date()
@@ -654,7 +670,7 @@ def date_trunc(field, x):
 
 @function([str, datetime.date], int)
 def date_part(field, x):
-    """Extract the specified field from a date."""
+    """Extract the specified field from a date. The first argument can be 'weekday', 'dow', 'week', 'month', 'quarter', 'year', 'isoyear', 'decade', 'century', 'millennium'. The second is the date to extract the field from."""
     if field == 'weekday' or field == 'dow':
         return x.weekday()
     if field == 'isoweekday' or field == 'isodow':
@@ -709,10 +725,7 @@ def interval(x):
 
 @function([relativedelta, datetime.date, datetime.date], datetime.date)
 def date_bin(stride, source, origin):
-    """Bin a date into the specified stride aligned with the specified origin.
-
-    As an extension to the the SQL standard ``date_bin()`` function this
-    function also accepts strides containing units of months and years.
+    """See date_bin(str, date, date). This variant accepts a relative time interval, as generated by interval().
     """
     if stride.months or stride.years:
         if origin + stride <= origin:
@@ -747,6 +760,14 @@ def date_bin(stride, source, origin):
 
 @function([str, datetime.date, datetime.date], datetime.date, name='date_bin')
 def date_bin_str(stride, source, origin):
+    """Bin a date into the specified stride aligned with the specified origin.
+
+    As an extension to the the SQL standard ``date_bin()`` function this
+    function also accepts strides containing units of months and years.
+    
+    Arguments:
+      stride: A string representing a time interval, e.g. '1 day', '1 month', '1 year'; source: The date to bin; origin: The start of the binning interval
+    """
     return date_bin(interval(stride), source, origin)
 
 

--- a/beanquery/query_env.py
+++ b/beanquery/query_env.py
@@ -185,7 +185,7 @@ def str_(x):
     return str(x)
 
 
-@function([datetime.date], datetime.date, groups=['atomic', 'date'])
+@function([datetime.date], datetime.date, name = 'date', groups=['date'])
 @function([str], datetime.date, name='date', groups=['atomic', 'date'])
 @function([object], datetime.date, name='date', groups=['atomic', 'date'])
 def date_(x):
@@ -420,30 +420,30 @@ def open_meta(context, account, key=None):
 
 
 # Stub kept only for function type checking and for generating documentation.
-@function([str], object, groups=['transaction'])
+@function([str], object)
 def meta(context, key):
     """Get some metadata key of the posting."""
     raise NotImplementedError
 
 
 # Stub kept only for function type checking and for generating documentation.
-@function([str], object, groups=['transaction'])
+@function([str], object)
 def entry_meta(context, key):
     """Get some metadata key of the transaction."""
     raise NotImplementedError
 
 
 # Stub kept only for function type checking and for generating documentation.
-@function([str], object, groups=['posting'])
+@function([str], object)
 def any_meta(context, key):
     """Get metadata from the posting or its parent transaction if not present."""
     raise NotImplementedError
 
 
-@function([str], dict, pass_context=True)
-@function([str, str], object, pass_context=True)
-@function([str], dict, pass_context=True, name='commodity_meta')
-@function([str, str], object, pass_context=True, name='commodity_meta')
+@function([str], dict, pass_context=True, groups = ['amount'])
+@function([str, str], object, pass_context=True, groups = ['amount'])
+@function([str], dict, pass_context=True, name='commodity_meta', groups = ['amount'])
+@function([str, str], object, pass_context=True, name='commodity_meta', groups = ['amount'])
 def currency_meta(context, commodity, key=None):
     """Get the metadata dict of the commodity directive of the currency."""
     entry = context.tables['commodities'].commodities.get(commodity)
@@ -550,10 +550,10 @@ def inventory_value(context, inv, date=None):
     return inv.reduce(convert.get_value, price_map, date)
 
 
-@function([str, str], Decimal, pass_context=True)
+@function([str, str], Decimal, pass_context=True, groups = ['position'])
 @function([str, str, datetime.date], Decimal, pass_context=True, name='getprice')
 def getprice(context, base, quote, date=None):
-    """Fetch a price."""
+    """Fetch a price. Arguments: Base currency, e.g. 'EUR'; Commodity name (string); Date: Price as of this date. Default: Latest price."""
     price_map = context.tables['prices'].price_map
     pair = (base.upper(), quote.upper())
     _, price = prices.get_price(price_map, pair, date)
@@ -868,7 +868,7 @@ class SumAmount(query_compile.EvalAggregator):
             store[self.handle].add_amount(value)
 
 
-@aggregator([position.Position], name='sum', groups = ['position', 'inventory'])
+@aggregator([position.Position], name='sum', groups = ['position'])
 class SumPosition(query_compile.EvalAggregator):
     """Calculate the sum of the position. The result is an Inventory."""
     def __init__(self, context, operands):

--- a/beanquery/query_env.py
+++ b/beanquery/query_env.py
@@ -185,9 +185,9 @@ def str_(x):
     return str(x)
 
 
-@function([datetime.date], datetime.date, name='date')
-@function([str], datetime.date, name='date')
-@function([object], datetime.date, name='date')
+@function([datetime.date], datetime.date, groups=['atomic', 'date'])
+@function([str], datetime.date, name='date', groups=['atomic', 'date'])
+@function([object], datetime.date, name='date', groups=['atomic', 'date'])
 def date_(x):
     """Convert the argument to a date. The argument should be 
     a string in the format YYYY-MM-DD. Date objects are passed 
@@ -202,7 +202,7 @@ def date_(x):
     return None
 
 
-@function([int, int, int], datetime.date, name='date')
+@function([int, int, int], datetime.date, name='date', groups=['date'])
 def date_from_ymd(year, month, day):
     """Construct a date with year, month, day arguments."""
     try:
@@ -328,20 +328,20 @@ def today():
 
 # Operations on accounts.
 
-@function([str], str)
-@function([str, int], str)
+@function([str], str, groups=['account'])
+@function([str, int], str, groups=['account'])
 def root(acc, n=1):
     """Get the root name(s) of the account."""
     return account.root(n, acc)
 
 
-@function([str], str)
+@function([str], str, groups=['account'])
 def parent(acc):
     """Get the parent name of the account."""
     return account.parent(acc)
 
 
-@function([str], str)
+@function([str], str, groups=['account'])
 def leaf(acc):
     """Get the name of the leaf subaccount."""
     return account.leaf(acc)
@@ -387,7 +387,7 @@ def lower(string):
 NONENONE = None, None
 
 
-@function([str], datetime.date, pass_context=True)
+@function([str], datetime.date, pass_context=True, groups=['account'])
 def open_date(context, acc):
     """Get the date of the open directive of the account."""
     open_entry, _ = context.tables['accounts'].accounts.get(acc, NONENONE)
@@ -396,7 +396,7 @@ def open_date(context, acc):
     return open_entry.date
 
 
-@function([str], datetime.date, pass_context=True)
+@function([str], datetime.date, pass_context=True, groups=['account'])
 def close_date(context, acc):
     """Get the date of the close directive of the account."""
     _, close_entry = context.tables['accounts'].accounts.get(acc, NONENONE)
@@ -405,8 +405,8 @@ def close_date(context, acc):
     return close_entry.date
 
 
-@function([str], dict, pass_context=True)
-@function([str, str], object, pass_context=True)
+@function([str], dict, pass_context=True, groups=['account'])
+@function([str, str], object, pass_context=True, groups=['account'])
 def open_meta(context, account, key=None):
     """Get the metadata dict of the open directive of the account. 
     With one argument, returns all metadata as a dict object. With two
@@ -420,21 +420,21 @@ def open_meta(context, account, key=None):
 
 
 # Stub kept only for function type checking and for generating documentation.
-@function([str], object)
+@function([str], object, groups=['transaction'])
 def meta(context, key):
     """Get some metadata key of the posting."""
     raise NotImplementedError
 
 
 # Stub kept only for function type checking and for generating documentation.
-@function([str], object)
+@function([str], object, groups=['transaction'])
 def entry_meta(context, key):
     """Get some metadata key of the transaction."""
     raise NotImplementedError
 
 
 # Stub kept only for function type checking and for generating documentation.
-@function([str], object)
+@function([str], object, groups=['posting'])
 def any_meta(context, key):
     """Get metadata from the posting or its parent transaction if not present."""
     raise NotImplementedError
@@ -454,7 +454,7 @@ def currency_meta(context, commodity, key=None):
     return entry.meta.get(key)
 
 
-@function([str], str, pass_context=True)
+@function([str], str, pass_context=True, groups=['account'])
 def account_sortkey(context, acc):
     """Get a string to sort accounts in order taking into account the types."""
     account_types = context.tables['accounts'].types
@@ -463,7 +463,7 @@ def account_sortkey(context, acc):
 
 
 # Stub kept only for function type checking and for generating documentation.
-@function([str], bool)
+@function([str], bool, groups=['account'])
 def has_account(context, pattern):
     """True if the transaction has at least one posting matching the regular expression argument."""
     raise NotImplementedError
@@ -646,8 +646,8 @@ class Date(types.Structure):
 types.ALIASES[datetime.date] = Date
 
 
-@function([str], datetime.date)
-@function([str, str], datetime.date)
+@function([str], datetime.date, groups=['atomic', 'date'])
+@function([str, str], datetime.date, groups=['atomic', 'date'])
 def parse_date(string, frmt=None):
     """Parse date from string (first argument). Without second argument, 
     the 'dateutil' library is used to parse the string. This can deal with
@@ -691,7 +691,7 @@ def date_trunc(field, x):
     return None
 
 
-@function([str, datetime.date], int)
+@function([str, datetime.date], int, groups = ['date'])
 def date_part(field, x):
     """Extract the specified field from a date. The first argument can be 'weekday', 'dow', 'week', 'month', 'quarter', 'year', 'isoyear', 'decade', 'century', 'millennium'. The second is the date to extract the field from."""
     if field == 'weekday' or field == 'dow':
@@ -721,7 +721,7 @@ def date_part(field, x):
     return None
 
 
-@function([str], relativedelta)
+@function([str], relativedelta, groups = ['date'])
 def interval(x):
     """Construct a relative time interval."""
     m = re.fullmatch(r'([-+]?[0-9]+)\s+(day|month|year)s?', x)
@@ -746,7 +746,7 @@ def interval(x):
     return None
 
 
-@function([relativedelta, datetime.date, datetime.date], datetime.date)
+@function([relativedelta, datetime.date, datetime.date], datetime.date, groups = ['date'])
 def date_bin(stride, source, origin):
     """See date_bin(str, date, date). This variant accepts a relative time interval, as generated by interval().
     """
@@ -781,7 +781,7 @@ def date_bin(stride, source, origin):
         return result
 
 
-@function([str, datetime.date, datetime.date], datetime.date, name='date_bin')
+@function([str, datetime.date, datetime.date], datetime.date, name='date_bin', groups = ['date'])
 def date_bin_str(stride, source, origin):
     """Bin a date into the specified stride aligned with the specified origin.
 
@@ -795,6 +795,14 @@ def date_bin_str(stride, source, origin):
 
 
 def aggregator(intypes, name=None, groups=None):
+    """Decorator to register an aggregator function.
+    
+    Args:
+      intypes: A list of types that the aggregator can accept.
+      name: The name of the aggregator function.
+      groups: A list of groups that the aggregator belongs to. See the
+           function shell._describe_groups for a list of valid groups.
+    """
     def decorator(cls):
         cls.__intypes__ = intypes
         cls.__groups__ = groups or []
@@ -860,7 +868,7 @@ class SumAmount(query_compile.EvalAggregator):
             store[self.handle].add_amount(value)
 
 
-@aggregator([position.Position], name='sum')
+@aggregator([position.Position], name='sum', groups = ['position', 'inventory'])
 class SumPosition(query_compile.EvalAggregator):
     """Calculate the sum of the position. The result is an Inventory."""
     def __init__(self, context, operands):

--- a/beanquery/query_env.py
+++ b/beanquery/query_env.py
@@ -45,10 +45,23 @@ class ColumnsRegistry(dict):
         return decorator
 
 
-def function(intypes, outtype, pass_context=None, name=None):
+def function(intypes, outtype, pass_context=None, name=None, groups=None):
+    """Decorator to register a function in the query environment. Expects
+    to decorate a function that takes operands as arguments.
+    
+    Args:
+      intypes: List of input types.
+      outtype: Return value.
+      pass_context: Whether the function receives the context as first argument 
+           or is pure.
+      name: Name of the function.
+      groups: In which group(s) the function in the help output (list). See 
+           shell._describe_function for group names.
+    """
     def decorator(func):
         class Func(query_compile.EvalFunction):
             __intypes__ = intypes
+            __groups__ = groups or []
             pure = not pass_context
             def __init__(self, context, operands):
                 super().__init__(context, operands, outtype)
@@ -67,10 +80,20 @@ def function(intypes, outtype, pass_context=None, name=None):
     return decorator
 
 
-def register(name=None):
+def register(name=None, groups=None):
+    """Decorator to register a function in the query environment with
+    more fine-grained control. Expects to decorate a class that implements
+    the query_compile.EvalFunction interface.
+
+    Args:
+      name: Name of the function.
+      groups: In which group(s) the function in the help output (list). See 
+           shell._describe_function for group names.    
+    """
     def decorator(cls):
         if name is not None:
             cls.__name__ = name
+        cls.__groups__ = groups or []
         query_compile.FUNCTIONS[cls.__name__].append(cls)
         return cls
     return decorator
@@ -771,9 +794,10 @@ def date_bin_str(stride, source, origin):
     return date_bin(interval(stride), source, origin)
 
 
-def aggregator(intypes, name=None):
+def aggregator(intypes, name=None, groups=None):
     def decorator(cls):
         cls.__intypes__ = intypes
+        cls.__groups__ = groups or []
         if name is not None:
             cls.__name__ = name
         query_compile.FUNCTIONS[cls.__name__].append(cls)

--- a/beanquery/shell.py
+++ b/beanquery/shell.py
@@ -637,19 +637,11 @@ class BQLShell(DispatchingShell):
 
           {columns}
 
-          Functions
-          ---------
-
-          {functions}
-
-          Aggregate functions
-          -------------------
-
-          {aggregates}
+          For available functions and aggregates, see "help functions".
 
         """)
-        print(template.format(**_describe(self.context.tables['postings'],
-                                          query_compile.FUNCTIONS)), file=self.outfile)
+        print(template.format(**_describe_columns(self.context.tables['postings'].columns)),
+              file=self.outfile)
 
     def help_from(self):
         template = textwrap.dedent("""
@@ -662,14 +654,10 @@ class BQLShell(DispatchingShell):
 
           {columns}
 
-          Functions
-          ---------
-
-          {functions}
+          For available functions, see "help functions".
 
         """)
-        print(template.format(**_describe(self.context.tables['entries'],
-                                          query_compile.FUNCTIONS)),
+        print(template.format(columns=_describe_columns(self.context.tables['entries'].columns)),
               file=self.outfile)
 
     def help_where(self):
@@ -683,14 +671,31 @@ class BQLShell(DispatchingShell):
 
           {columns}
 
+          For available functions, see "help functions".
+
+        """)
+        print(template.format(columns=_describe_columns(self.context.tables['postings'].columns)),
+              file=self.outfile)
+
+    def help_functions(self):
+        """Show all available functions and aggregates."""
+        template = textwrap.dedent("""
+
           Functions
           ---------
 
           {functions}
 
+          Aggregates
+          ----------
+
+          {aggregates}
+
         """)
-        print(template.format(**_describe(self.context.tables['postings'],
-                                          query_compile.FUNCTIONS)), file=self.outfile)
+        print(template.format(
+            functions=_describe_functions(query_compile.FUNCTIONS, aggregates=False),
+            aggregates=_describe_functions(query_compile.FUNCTIONS, aggregates=True)
+        ), file=self.outfile)
 
 
 def _describe_columns(columns):

--- a/beanquery/shell.py
+++ b/beanquery/shell.py
@@ -47,6 +47,20 @@ except ImportError:
 HISTORY_FILENAME = '~/.config/beanquery/history'
 INIT_FILENAME = '~/.config/beanquery/init'
 
+# Type categories for function classification
+# These types are matched against the first input type of the function.
+# Functions can be force-assigned to one or more of these categories
+# by use of the group argument in the function decorators 'function',
+# 'register' or 'aggregate' in the 'query_env' module.
+TYPE_CATEGORIES = {
+    'amount': [amount.Amount],
+    'account': [],  # Must be manually assigned as account names are strings
+    'position': [position.Position],
+    'inventory': [inventory.Inventory],
+    'date': [datetime.date],
+    'atomic': []  # fallback, default category
+}
+
 
 class style:
     ERROR = '\033[31;1m'
@@ -751,20 +765,6 @@ def _describe_functions(functions, aggregates=False, type_filter=None):
             'date' - functions working on dates
             'atomic' - functions working on basic types (str, int, Decimal, bool)
     """
-    # Define type categories
-    # These types are matched agains the first input type of the function.
-    # Functions can be force-assigned to one or more of these categories
-    # by use of the group argument in the function decorators 'function',
-    # 'register' or 'aggregate' in the 'query_env' module.
-    type_categories = {
-        'amount': [amount.Amount],
-        'account': [],  # Must by manually assigned as account names are strings
-        'position': [position.Position],
-        'inventory': [inventory.Inventory],
-        'date': [datetime.date],
-        'atomic': [] # fallback, default category
-    }
-    
     def get_type_category(input_types):
         """Determine the category of a function based on its first input type."""
         if not input_types:
@@ -773,7 +773,7 @@ def _describe_functions(functions, aggregates=False, type_filter=None):
         first_type = input_types[0]
         
         # Check each category for direct type match
-        for category, type_set in type_categories.items():
+        for category, type_set in TYPE_CATEGORIES.items():
             if first_type in type_set:
                 return category
         

--- a/beanquery/shell.py
+++ b/beanquery/shell.py
@@ -3,6 +3,7 @@ __license__ = "GNU GPLv2"
 
 import atexit
 import cmd
+import datetime
 import importlib
 import io
 import itertools
@@ -17,13 +18,15 @@ import warnings
 
 from contextlib import nullcontext, suppress
 from dataclasses import dataclass, asdict
+from decimal import Decimal
 from os import path
+
 
 import click
 import beancount
 
 from beancount.parser import printer
-from beancount.core import data
+from beancount.core import data, amount, position, inventory
 from beancount.utils import pager
 from beancount.utils.misc_utils import get_screen_height
 
@@ -678,13 +681,35 @@ class BQLShell(DispatchingShell):
               file=self.outfile)
 
     def help_functions(self):
-        """Show all available functions and aggregates."""
+        """Show all available functions and aggregates grouped by type."""
         template = textwrap.dedent("""
 
-          Functions
-          ---------
+          Functions are organized by the type of their first argument:
 
-          {functions}
+          Amount Functions (work on amounts)
+          --------------------------------
+
+          {amount_functions}
+
+          Position Functions (work on positions)
+          ------------------------------------
+
+          {position_functions}
+
+          Inventory Functions (work on inventories)
+          ---------------------------------------
+
+          {inventory_functions}
+
+          Date Functions (work on dates)
+          ----------------------------
+
+          {date_functions}
+
+          Atomic Functions (work on basic types: strings, numbers, etc.)
+          -----------------------------------------------------------
+
+          {atomic_functions}
 
           Aggregates
           ----------
@@ -693,7 +718,11 @@ class BQLShell(DispatchingShell):
 
         """)
         print(template.format(
-            functions=_describe_functions(query_compile.FUNCTIONS, aggregates=False),
+            amount_functions=_describe_functions(query_compile.FUNCTIONS, aggregates=False, type_filter='amount'),
+            position_functions=_describe_functions(query_compile.FUNCTIONS, aggregates=False, type_filter='position'),
+            inventory_functions=_describe_functions(query_compile.FUNCTIONS, aggregates=False, type_filter='inventory'),
+            date_functions=_describe_functions(query_compile.FUNCTIONS, aggregates=False, type_filter='date'),
+            atomic_functions=_describe_functions(query_compile.FUNCTIONS, aggregates=False, type_filter='atomic'),
             aggregates=_describe_functions(query_compile.FUNCTIONS, aggregates=True)
         ), file=self.outfile)
 
@@ -708,16 +737,77 @@ def _describe_columns(columns):
     return out.getvalue().rstrip()
 
 
-def _describe_functions(functions, aggregates=False):
+def _describe_functions(functions, aggregates=False, type_filter=None):
+    """Describe functions, optionally filtered by input type category.
+    
+    Args:
+        functions: Dictionary of function name -> list of function implementations
+        aggregates: If True, show aggregates; if False, show regular functions
+        type_filter: Optional filter by input type category:
+            'amount' - functions working on amounts
+            'account' - functions working on account names
+            'position' - functions working on positions
+            'inventory' - functions working on inventories
+            'date' - functions working on dates
+            'atomic' - functions working on basic types (str, int, Decimal, bool)
+    """
+    # Define type categories
+    # These types are matched agains the first input type of the function.
+    # Functions can be force-assigned to one or more of these categories
+    # by use of the group argument in the function decorators 'function',
+    # 'register' or 'aggregate' in the 'query_env' module.
+    type_categories = {
+        'amount': [amount.Amount],
+        'account': [],  # Must by manually assigned as account names are strings
+        'position': [position.Position],
+        'inventory': [inventory.Inventory],
+        'date': [datetime.date],
+        'atomic': [] # fallback, default category
+    }
+    
+    def get_type_category(input_types):
+        """Determine the category of a function based on its first input type."""
+        if not input_types:
+            return 'atomic'
+        
+        first_type = input_types[0]
+        
+        # Check each category for direct type match
+        for category, type_set in type_categories.items():
+            if first_type in type_set:
+                return category
+        
+        return 'atomic'  # Default fallback
+    
     entries = []
     for name, funcs in functions.items():
+        # Choice of whether to report aggregate or non-aggregate functions
         if aggregates != issubclass(funcs[0], query_compile.EvalAggregator):
             continue
+
         name = name.lower()
+
+        # Iterate through functions of the same name, but with different 
+        # signatures to filter by requested type category
         for func in funcs:
+            # Apply type filter if specified
+            if type_filter:
+                # Check if function has explicit groups
+                if hasattr(func, '__groups__') and func.__groups__:
+                    # Use explicit groups for filtering
+                    if type_filter not in func.__groups__:
+                        continue
+                else:
+                    # Use type-based categorization for filtering
+                    func_category = get_type_category(func.__intypes__)
+                    if func_category != type_filter:
+                        continue
+            
+            # Assemble function signature for output
             args = ', '.join(types.name(d) for d in func.__intypes__)
             doc = re.sub(r'[ \n\t]+', ' ', func.__doc__ or '')
             entries.append((name, doc, args))
+    
     entries.sort()
     out = io.StringIO()
     wrapper = textwrap.TextWrapper(initial_indent='  ', subsequent_indent='  ', width=80)

--- a/beanquery/shell.py
+++ b/beanquery/shell.py
@@ -55,10 +55,18 @@ INIT_FILENAME = '~/.config/beanquery/init'
 TYPE_CATEGORIES = {
     'amount': [amount.Amount],
     'account': [],  # Must be manually assigned as account names are strings
-    'position': [position.Position],
-    'inventory': [inventory.Inventory],
+    'position': [position.Position, inventory.Inventory],
     'date': [datetime.date],
     'atomic': []  # fallback, default category
+}
+
+# Category information for help display. Tuples: (title, description)
+CATEGORY_INFO = {
+    'amount': ("Amount and Commodity Functions", "An amount is a value with a currency/commodity."),
+    'account': ("Account Functions", ""),
+    'position': ("Position & Inventory Functions", "A position is a single amount held at cost.\n\nExample: 10 HOOL {100.30 USD}\n\nA collection of multiple positions is an inventory"),
+    'date': ("Date Functions", ""),
+    'atomic': ("Atomic Functions", "Work on basic types: strings, numbers, etc.")
 }
 
 
@@ -296,7 +304,27 @@ class DispatchingShell(cmd.Cmd):
 
     def do_help(self, arg):
         """List available commands with "help" or detailed help with "help cmd"."""
-        super().do_help(arg.lower())
+        if not arg:
+            super().do_help(arg)
+            return
+            
+        # Split arg by space to get command and additional arguments
+        # e.g. "help functions amount" -> command="functions", args=["amount"]
+        parts = arg.split()
+        command = parts[0].lower()
+        args = parts[1:] if len(parts) > 1 else []
+        
+        # Check if there's a help method for this command
+        help_method = getattr(self, f'help_{command}', None)
+        if help_method and args:
+            # Call the help method with the additional arguments
+            try:
+                help_method(' '.join(args))
+            except TypeError:
+                # Fallback if the help method doesn't accept arguments
+                super().do_help(command)
+        else:
+            super().do_help(command)
 
     def do_history(self, arg):
         """Print the command-line history."""
@@ -575,9 +603,9 @@ class BQLShell(DispatchingShell):
             directive are made available in this context as well. Simple functions
             (that return a single value per row) and aggregation functions (that
             return a single value per group) are available. For the complete
-            list of supported columns and functions, see help on "targets".
-            You can also provide a wildcard here, which will select a reasonable
-            default set of columns for rendering a journal.
+            list of supported columns and functions, see help on "targets" and 
+            "functions". You can also provide a wildcard here, which will 
+            select a reasonable default set of columns for rendering a journal.
 
           from_expr: A logical expression that matches on the attributes of
             the directives (not postings). This allows you to select a subset of
@@ -654,10 +682,13 @@ class BQLShell(DispatchingShell):
 
           {columns}
 
+          ----------------------------------------------------------------------
+
           For available functions and aggregates, see "help functions".
 
         """)
-        print(template.format(**_describe_columns(self.context.tables['postings'].columns)),
+
+        print(template.format(columns = _describe_columns(self.context.tables['postings'].columns)),
               file=self.outfile)
 
     def help_from(self):
@@ -694,51 +725,82 @@ class BQLShell(DispatchingShell):
         print(template.format(columns=_describe_columns(self.context.tables['postings'].columns)),
               file=self.outfile)
 
-    def help_functions(self):
-        """Show all available functions and aggregates grouped by type."""
-        template = textwrap.dedent("""
-
-          Functions are organized by the type of their first argument:
-
-          Amount Functions (work on amounts)
-          --------------------------------
-
-          {amount_functions}
-
-          Position Functions (work on positions)
-          ------------------------------------
-
-          {position_functions}
-
-          Inventory Functions (work on inventories)
-          ---------------------------------------
-
-          {inventory_functions}
-
-          Date Functions (work on dates)
-          ----------------------------
-
-          {date_functions}
-
-          Atomic Functions (work on basic types: strings, numbers, etc.)
-          -----------------------------------------------------------
-
-          {atomic_functions}
-
-          Aggregates
-          ----------
-
-          {aggregates}
-
-        """)
-        print(template.format(
-            amount_functions=_describe_functions(query_compile.FUNCTIONS, aggregates=False, type_filter='amount'),
-            position_functions=_describe_functions(query_compile.FUNCTIONS, aggregates=False, type_filter='position'),
-            inventory_functions=_describe_functions(query_compile.FUNCTIONS, aggregates=False, type_filter='inventory'),
-            date_functions=_describe_functions(query_compile.FUNCTIONS, aggregates=False, type_filter='date'),
-            atomic_functions=_describe_functions(query_compile.FUNCTIONS, aggregates=False, type_filter='atomic'),
-            aggregates=_describe_functions(query_compile.FUNCTIONS, aggregates=True)
-        ), file=self.outfile)
+    def help_functions(self, arg=None):
+        """Show all available functions and aggregates grouped by type.
+        
+        Usage: help functions [type]
+        
+        Without type argument, shows only category descriptions.
+        With type argument, shows functions for that specific type.
+        Available types: amount, position, date, atomic, aggregates
+        """
+        if arg is None:
+            arg = ''
+        else:
+            arg = arg.strip().lower()
+        
+        
+        if not arg:
+            # Show only category descriptions when no type specified
+            sections = []
+            sections.append("\nUsage: help functions [type]\n")
+            sections.append("Functions are organized by the type of their main argument:\n")
+            
+            for category in TYPE_CATEGORIES.keys():                    
+                title, description = CATEGORY_INFO.get(category, (f"{category.title()} Functions", ""))
+                section = f"  {category}: {title}"
+                if description:
+                    section += f" - {description}"
+                sections.append(section)
+            
+            # Add aggregates info
+            sections.append("  aggregates: Aggregation Functions - Functions that compute summary values across groups, as defined by the SELECT ... GROUP BY clause.")
+            
+            # Format output with proper wrapping and indentation
+            wrapper = textwrap.TextWrapper(width=80, subsequent_indent='    ')
+            formatted_sections = []
+            for section in sections:
+                if section.startswith('  '):
+                    # For category lines, wrap with proper indentation
+                    wrapped = wrapper.fill(section)
+                    formatted_sections.append(wrapped)
+                else:
+                    # For headers and usage, keep as is
+                    formatted_sections.append(section)
+            print('\n'.join(formatted_sections), file=self.outfile)
+            return
+        
+        # Show functions for specific type
+        if arg == 'aggregates':
+            aggregates_content = _describe_functions(query_compile.FUNCTIONS, aggregates=True)
+            if aggregates_content.strip():
+                print("Aggregates\n----------\n", file=self.outfile)
+                print(aggregates_content, file=self.outfile)
+            else:
+                print("No aggregate functions found.", file=self.outfile)
+            return
+        
+        if arg not in TYPE_CATEGORIES:
+            available_types = list(TYPE_CATEGORIES.keys()) + ['aggregates']
+            available_types = [t for t in available_types if t != 'account']  # Skip account
+            print(f"Unknown type '{arg}'. Available types: {', '.join(available_types)}", file=self.outfile)
+            return
+        
+        if arg == 'account':
+            print("Account functions are manually assigned and may not have dedicated functions.", file=self.outfile)
+            return
+        
+        title, description = CATEGORY_INFO.get(arg, (f"{arg.title()} Functions", ""))
+        underline = '-' * len(title)
+        functions_content = _describe_functions(query_compile.FUNCTIONS, aggregates=False, type_filter=arg)
+        
+        if functions_content.strip():
+            print(f"{title}\n{underline}", file=self.outfile)
+            if description:
+                print(f"\n{description}", file=self.outfile)
+            print(f"\n{functions_content}", file=self.outfile)
+        else:
+            print(f"No functions found for type '{arg}'.", file=self.outfile)
 
 
 def _describe_columns(columns):


### PR DESCRIPTION

As someone new to beancount, I found the function documentation really hard to navigate. The old `help functions` dumped everything on screen at once, which was overwhelming. While developing a BQL query, I found myself looking for functions to transform certain argument types, however I just had an alphabetical function list. 

## What I changed:

**Progressive disclosure**: 
- `help functions` now shows just a category overview (takes ~10 lines instead of 100+) and explains custom object types
- `help functions amount` shows only amount-related functions, same for `date`, `position`, `atomic`,...

**Better function docs**:
- Added argument explanations to some functions (the old docs assumed you knew what arguments meant)
- Example: `grep(pattern, string)` now explains "pattern" is a regex and "string" is input text
- Examples on some types, e.g. `Position` is something like  `10 HOOL {100.30 USD}`

**Technical implementation**:
- Query functions are grouped according to their first argument's type by `_describe_function()`.
- In addition, the decorators `@function`, `@register` and `@aggregator` take a `group=` argument to refine (e.g. for account names, which are strings)

The main benefit is you can find functions now much easier without scrolling through pages of text. When I started with beancount, I had no idea what functions were available or how to use them - I hope this makes it easier.