### PR TITLE
fix: Fix Tatsu dependency issue

### DIFF
--- a/beanquery/parser/parser.py
+++ b/beanquery/parser/parser.py
@@ -20,7 +20,7 @@ from tatsu.buffering import Buffer
 from tatsu.parsing import Parser
 from tatsu.parsing import tatsumasu
 from tatsu.parsing import leftrec, nomemo, isname
-from tatsu.infos import ParserConfig
+from tatsu.parserconfig import ParserConfig
 from tatsu.util import re, generic_main
 
 


### PR DESCRIPTION
Problem: Tatsu made a breaking change in this
[commit](https://github.com/neogeny/TatSu/commit/938bf9cbe0e91a501f04221d2576c931dac775ff#diff-6fa32e86899dffc2cc0af96073a1d44b2435e7533984a0bdc90f886ad0d7c256)

Solution: change the import module from `tatsu.parserconfig` to `tatsu.parserconfig`

Testing: ran the main() in __main__.py on my file

Issue: https://github.com/beancount/beanquery/issues/268