### PR TITLE
shell: Allow to configure history and init files path via env vars

### DIFF
--- a/beanquery/shell.py
+++ b/beanquery/shell.py
@@ -41,10 +41,6 @@ except ImportError:
     readline = None
 
 
-HISTORY_FILENAME = '~/.config/beanquery/history'
-INIT_FILENAME = '~/.config/beanquery/init'
-
-
 class style:
     ERROR = '\033[31;1m'
     WARNING = '\033[31;1m'
@@ -160,6 +156,10 @@ class DispatchingShell(cmd.Cmd):
         self.color = interactive and os.environ.get('TERM', 'dumb') != 'dumb'
         self.add_help()
 
+        home_config = os.environ.get('XDG_CONFIG_HOME', '~/.config')
+        history_filename = path.expanduser(os.environ.get('BEANQUERY_HISTORY', path.join(home_config, 'beanquery/history')))
+        init_filename = path.expanduser(os.environ.get('BEANQUERY_INIT', path.join(home_config, 'beanquery/init')))
+
         if interactive and readline is not None:
 
             # Setup completion on ``tab``. This needs to be done differently
@@ -181,18 +181,18 @@ class DispatchingShell(cmd.Cmd):
             readline.set_completer_delims(" \t\n\"\\'`@$><=;|&{(")
 
             # Setup ``readline`` history handling.
-            history_filepath = path.expanduser(HISTORY_FILENAME)
-            os.makedirs(path.dirname(history_filepath), exist_ok=True)
-            with suppress(FileNotFoundError):
-                readline.read_history_file(history_filepath)
-                readline.set_history_length(2048)
-            atexit.register(readline.write_history_file, history_filepath)
+            if history_filename:
+                os.makedirs(path.dirname(history_filename), exist_ok=True)
+                with suppress(FileNotFoundError):
+                    readline.read_history_file(history_filename)
+                    readline.set_history_length(2048)
+                atexit.register(readline.write_history_file, history_filename)
 
         warnings.showwarning = self.warning
 
-        if runinit:
+        if runinit and init_filename:
             with suppress(FileNotFoundError):
-                with open(path.expanduser(INIT_FILENAME)) as f:
+                with open(init_filename) as f:
                     for line in f:
                         self.onecmd(line)
 

--- a/beanquery/shell_test.py
+++ b/beanquery/shell_test.py
@@ -326,18 +326,10 @@ class ClickTestCase(unittest.TestCase):
     """Base class for command-line program test cases."""
 
     def main(self, *args):
-        init_filename = shell.INIT_FILENAME
-        history_filename = shell.HISTORY_FILENAME
-        try:
-            shell.INIT_FILENAME = ''
-            shell.HISTORY_FILENAME = ''
-            runner = click.testing.CliRunner()
-            result = runner.invoke(shell.main, args, catch_exceptions=False)
-            self.assertEqual(result.exit_code, 0)
-            return result
-        finally:
-            shell.INIT_FILENAME = init_filename
-            shell.HISTORY_FILENAME = history_filename
+        runner = click.testing.CliRunner(env={'BEANQUERY_HISTORY': '', 'BEANQUERY_INIT': ''})
+        result = runner.invoke(shell.main, args, catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
+        return result
 
 
 class TestShell(ClickTestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,8 @@ ignore = [
     'PLW1641', # eq-without-hash
     'PLW2901',
     'RUF012',
-    'RUF023',  # unsorted-dunder-slots
+    'RUF023', # unsorted-dunder-slots
+    'RUF059', # unused-unpacked-variable
     'UP007',
     'UP032',
 ]


### PR DESCRIPTION
Allow to customize the location of the shell history files via the BEANQUERY_HISTORY environment variables. The environment variable name has been chosen to resemble the ones used by sqlite3 and psql, but with the BEANQUERY_ prefix.

Similarly, allow to customize the location of the init file via the BEANQUERY_INIT environment variable.

Furthermore, respect the XGD_CONFIG_HOME environment variable when determining the default location of these files.

Tilde expansion is performed on the values of all environment variables: a leading path component equal to ~ is expanded to the user's home directory location.

Fixes #272.