### PR TITLE
fix: prevent precision loss in AmountRenderer when quantizing

### DIFF
--- a/beanquery/query_render.py
+++ b/beanquery/query_render.py
@@ -248,9 +248,6 @@ class AmountRenderer(ColumnRenderer):
 
     def __init__(self, ctx):
         super().__init__(ctx)
-        # Use the display context inferred from the input ledger to
-        # determine the quantization of the column values.
-        self.quantize = ctx.dcontext.quantize
         # Use column specific display context for formatting.
         self.dcontext = _DisplayContext()
         # Maximum width of the commodity symbol.
@@ -259,8 +256,12 @@ class AmountRenderer(ColumnRenderer):
     def update(self, value):
         # Need to handle None to reuse this in PositionRenderer.
         if value is not None:
-            number = self.quantize(value.number, value.currency)
-            self.dcontext.update(number, value.currency)
+            # Update the column display context with the original number's
+            # precision, not the quantized precision. Using the quantized
+            # number here caused precision loss: if most amounts for a
+            # currency are integers (e.g., -1 USD), the quantized precision
+            # is 0, and amounts like 111.11 USD would display as 111 USD.
+            self.dcontext.update(value.number, value.currency)
             self.curwidth = max(self.curwidth, len(value.currency))
 
     def prepare(self):


### PR DESCRIPTION
## Problem

`AmountRenderer.update()` quantizes numbers using the input ledger's display context before updating the column-local display context. When most amounts for a currency are integers (e.g., `-1 USD`, `500 USD`), the ledger display context has 0 decimal places for that currency, causing `111.11 USD` to be quantized to `111 USD`.

This affects both `position` column display and `SUM(position)` aggregation:

```
$ bean-query test.beancount "SELECT account, SUM(position) WHERE account = 'Assets:Bank'"
Assets:Bank  910 USD     ← should be 910.11 USD

$ bean-query test.beancount "SELECT account, SUM(number) WHERE account = 'Assets:Bank'"
Assets:Bank  910.11       ← correct
```

## Fix

Update the column display context with the **original** number's precision instead of the quantized value. Remove the now-unused `self.quantize` attribute.

The `format()` method already uses `value.number` (the original), so only the column display context width calculation was affected.

## Verification

Tested with the reproduction case from #275:
- Before: `111.11 USD` displays as `111 USD`, `SUM(position)` = `910 USD`
- After: `111.11 USD` displays correctly, `SUM(position)` = `910.11 USD`

Fixes #275